### PR TITLE
Add main screen player view

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Start the server with:
 node server.js
 ```
 
+Visit `http://localhost:3000/` in a browser to see the main screen with the
+current video and a list of upcoming singers.
+
 Endpoints:
 - `POST /sessions` – creates a new session and returns a room code and QR code.
 - `POST /sessions/:code/join` with `name` and optional `deviceId` – joins a

--- a/Tasks.md
+++ b/Tasks.md
@@ -15,7 +15,7 @@ This checklist captures the work required to deliver the features outlined in **
 - [x] Provide a YouTube search interface with the term "karaoke" automatically appended.
 - [x] Accept direct YouTube links with video previews.
 - [x] Add songs to a shared queue, limiting each guest to three pending songs.
-- [ ] Display the video player and next singers on the main screen.
+- [x] Display the video player and next singers on the main screen.
 - [ ] Implement the "Fair Play" queue algorithm with Phase 1 and Phase 2 behavior.
 - [ ] Build a KJ control panel for reordering, removing, replacing, skipping, and pausing songs.
 

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Karaoke MN</title>
+  <style>
+    body { font-family: sans-serif; text-align: center; }
+    #player { margin-top: 20px; }
+  </style>
+</head>
+<body>
+  <h1>Karaoke MN</h1>
+  <div id="player"></div>
+  <h2>Next Singers</h2>
+  <ol id="next"></ol>
+
+  <script src="https://www.youtube.com/iframe_api"></script>
+  <script>
+    let player;
+    async function fetchQueue() {
+      const res = await fetch('/queue');
+      return res.ok ? res.json() : [];
+    }
+    async function update() {
+      const queue = await fetchQueue();
+      if (!queue.length) return;
+      if (!player) {
+        player = new YT.Player('player', {
+          height: '390',
+          width: '640',
+          videoId: queue[0].videoId
+        });
+      } else {
+        const currentId = player.getVideoData().video_id;
+        if (queue[0].videoId !== currentId) {
+          player.loadVideoById(queue[0].videoId);
+        }
+      }
+      const list = document.getElementById('next');
+      list.innerHTML = '';
+      queue.slice(1, 6).forEach(item => {
+        const li = document.createElement('li');
+        li.textContent = item.singer;
+        list.appendChild(li);
+      });
+    }
+    function onYouTubeIframeAPIReady() {
+      update();
+      setInterval(update, 5000);
+    }
+  </script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@ const QRCode = require('qrcode');
 
 const app = express();
 app.use(bodyParser.json());
+app.use(express.static('public'));
 
 const apiKey = process.env.YOUTUBE_API_KEY;
 if (!apiKey) {


### PR DESCRIPTION
## Summary
- serve static files from `public`
- add player web page showing current video and upcoming singers
- document player view in README
- check off player screen task in TODOs

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68485ad21304832595e78c55841100db