### PR TITLE
Add Fair Play queue algorithm

### DIFF
--- a/__tests__/fairPlay.test.js
+++ b/__tests__/fairPlay.test.js
@@ -1,0 +1,24 @@
+const { getFairQueue } = require('../fairPlay');
+
+test('new singer prioritized in phase 1', () => {
+  const queue = [
+    { id: '1', singer: 'A' },
+    { id: '2', singer: 'A' },
+    { id: '3', singer: 'B' },
+  ];
+  const stats = { A: { songsSung: 0 }, B: { songsSung: 0 } };
+  const ordered = getFairQueue(queue, stats, false);
+  expect(ordered.map(s => s.id)).toEqual(['1', '3', '2']);
+});
+
+test('phase 2 prioritizes fewest songs sung', () => {
+  const queue = [
+    { id: '1', singer: 'A' },
+    { id: '2', singer: 'B' },
+    { id: '3', singer: 'A' },
+  ];
+  const stats = { A: { songsSung: 1 }, B: { songsSung: 0 } };
+  const ordered = getFairQueue(queue, stats, true);
+  expect(ordered.map(s => s.id)).toEqual(['2', '1', '3']);
+});
+

--- a/fairPlay.js
+++ b/fairPlay.js
@@ -1,0 +1,42 @@
+function getFairQueue(queue, singerStats = {}, phase2 = false) {
+  const bySinger = {};
+  queue.forEach((song, index) => {
+    if (!bySinger[song.singer]) bySinger[song.singer] = [];
+    bySinger[song.singer].push({ ...song, order: index });
+  });
+
+  const indexes = {};
+  const counts = {};
+  Object.keys(bySinger).forEach(s => {
+    indexes[s] = 0;
+    counts[s] = (singerStats[s] && singerStats[s].songsSung) || 0;
+  });
+
+  const result = [];
+  while (result.length < queue.length) {
+    let bestSinger = null;
+    let bestScore = Infinity;
+    let bestOrder = Infinity;
+    for (const singer in bySinger) {
+      if (indexes[singer] >= bySinger[singer].length) continue;
+      const base = phase2 ? counts[singer] : Math.min(1, counts[singer]);
+      const score = base + indexes[singer];
+      const order = bySinger[singer][indexes[singer]].order;
+      if (
+        bestSinger === null ||
+        score < bestScore ||
+        (score === bestScore && order < bestOrder)
+      ) {
+        bestSinger = singer;
+        bestScore = score;
+        bestOrder = order;
+      }
+    }
+    const song = bySinger[bestSinger][indexes[bestSinger]];
+    indexes[bestSinger]++;
+    result.push(song);
+  }
+  return result;
+}
+
+module.exports = { getFairQueue };


### PR DESCRIPTION
## Summary
- implement `getFairQueue` algorithm
- use Fair Play ordering for `/queue`
- track `songsSung` and allow songs to be completed
- add `/phase2` endpoint to start looping phase
- test Fair Play queue logic

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848727a5af083258057f9288d6cd68c