### PR TITLE
Implement passkey auth for KJ

### DIFF
--- a/Tasks.md
+++ b/Tasks.md
@@ -9,7 +9,7 @@ This checklist captures the work required to deliver the features outlined in **
 - [x] Acquire a YouTube API key for search.
 
 ## Core Functionality
-- [ ] Implement passkey-based authentication for the KJ account.
+- [x] Implement passkey-based authentication for the KJ account.
 - [x] Create a session creation flow with room code and QR code display.
 - [x] Allow guests to join anonymously and bind their singer names to their devices.
 - [x] Provide a YouTube search interface with the term "karaoke" automatically appended.

--- a/kjAuth.js
+++ b/kjAuth.js
@@ -1,0 +1,86 @@
+const {
+  generateRegistrationOptions,
+  verifyRegistrationResponse,
+  generateAuthenticationOptions,
+  verifyAuthenticationResponse,
+} = require('@simplewebauthn/server');
+
+const rpID = process.env.RP_ID || 'localhost';
+const origin = process.env.ORIGIN || `http://${rpID}:3000`;
+const rpName = 'Karaoke MN';
+
+const kjUser = {
+  id: 'kj',
+  username: 'KJ',
+  devices: [],
+  currentChallenge: null,
+};
+
+function getUser() {
+  return kjUser;
+}
+
+function getUserDevice(rawId) {
+  const idBuffer = Buffer.from(rawId, 'base64url');
+  return kjUser.devices.find((dev) => dev.credentialID.equals(idBuffer));
+}
+
+function generateRegistration() {
+  const user = getUser();
+  const opts = generateRegistrationOptions({
+    rpName,
+    rpID,
+    userID: user.id,
+    userName: user.username,
+    attestationType: 'none',
+    authenticatorSelection: { userVerification: 'preferred' },
+    excludeCredentials: user.devices.map((d) => ({ id: d.credentialID, type: 'public-key' })),
+  });
+  user.currentChallenge = opts.challenge;
+  return opts;
+}
+
+async function verifyRegistration(credential) {
+  const user = getUser();
+  const verification = await verifyRegistrationResponse({
+    credential,
+    expectedChallenge: user.currentChallenge,
+    expectedOrigin: origin,
+    expectedRPID: rpID,
+    requireUserVerification: true,
+  });
+  if (verification.verified && verification.registrationInfo) {
+    const { credentialPublicKey, credentialID, counter } = verification.registrationInfo;
+    user.devices.push({ credentialID, publicKey: credentialPublicKey, counter });
+  }
+  return verification.verified;
+}
+
+function generateAuth() {
+  const user = getUser();
+  const opts = generateAuthenticationOptions({
+    rpID,
+    userVerification: 'preferred',
+    allowCredentials: user.devices.map((d) => ({ id: d.credentialID, type: 'public-key' })),
+  });
+  user.currentChallenge = opts.challenge;
+  return opts;
+}
+
+async function verifyAuth(credential) {
+  const user = getUser();
+  const device = getUserDevice(credential.rawId);
+  const verification = await verifyAuthenticationResponse({
+    credential,
+    expectedChallenge: user.currentChallenge,
+    expectedOrigin: origin,
+    expectedRPID: rpID,
+    authenticator: device,
+  });
+  if (verification.verified && verification.authenticationInfo && device) {
+    device.counter = verification.authenticationInfo.newCounter;
+  }
+  return verification.verified;
+}
+
+module.exports = { generateRegistration, verifyRegistration, generateAuth, verifyAuth };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@simplewebauthn/server": "^13.1.1",
         "body-parser": "^1.20.2",
         "express": "^4.19.2",
         "firebase-admin": "^12.0.0",
@@ -783,6 +784,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/@hexagon/base64": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
+      "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
+      "license": "MIT"
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1166,6 +1173,12 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/@levischuck/tiny-cbor": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
+      "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
+      "license": "MIT"
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -1174,6 +1187,64 @@
       "optional": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@peculiar/asn1-android": {
+      "version": "2.3.16",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.3.16.tgz",
+      "integrity": "sha512-a1viIv3bIahXNssrOIkXZIlI2ePpZaNmR30d4aBL99mu2rO+mT9D6zBsp7H6eROWGtmwv0Ionp5olJurIo09dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.15",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.3.15.tgz",
+      "integrity": "sha512-/HtR91dvgog7z/WhCVdxZJ/jitJuIu8iTqiyWVgRE9Ac5imt2sT/E4obqIVGKQw7PIy+X6i8lVBoT6wC73XUgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.15",
+        "@peculiar/asn1-x509": "^2.3.15",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.3.15.tgz",
+      "integrity": "sha512-p6hsanvPhexRtYSOHihLvUUgrJ8y0FtOM97N5UEpC+VifFYyZa0iZ5cXjTkZoDwxJ/TTJ1IJo3HVTB2JJTpXvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.15",
+        "@peculiar/asn1-x509": "^2.3.15",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.15.tgz",
+      "integrity": "sha512-QPeD8UA8axQREpgR5UTAfu2mqQmm97oUqahDtNdBcfj3qAnoXzFdQW+aNf/tD2WVXF8Fhmftxoj0eMIT++gX2w==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.3.15.tgz",
+      "integrity": "sha512-0dK5xqTqSLaxv1FHXIcd4Q/BZNuopg+u1l23hT9rOmQ1g4dNtw0g/RnEi+TboB0gOwGtrWn269v27cMgchFIIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.15",
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -1239,6 +1310,24 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@simplewebauthn/server": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-13.1.1.tgz",
+      "integrity": "sha512-1hsLpRHfSuMB9ee2aAdh0Htza/X3f4djhYISrggqGe3xopNjOcePiSDkDDoPzDYaaMCrbqGP1H2TYU7bgL9PmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hexagon/base64": "^1.1.27",
+        "@levischuck/tiny-cbor": "^0.2.2",
+        "@peculiar/asn1-android": "^2.3.10",
+        "@peculiar/asn1-ecc": "^2.3.8",
+        "@peculiar/asn1-rsa": "^2.3.8",
+        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/asn1-x509": "^2.3.8"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -1652,6 +1741,20 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.6.tgz",
+      "integrity": "sha512-UOCGPYbl0tv8+006qks/dTgV9ajs97X2p0FAbyS2iyCRrmLSRolDaHdp+v/CLgnzHc3fVB+CwYiUmei7ndFcgA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/async-retry": {
@@ -5336,6 +5439,24 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/qrcode": {
       "version": "1.5.4",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "@simplewebauthn/server": "^13.1.1",
     "body-parser": "^1.20.2",
     "express": "^4.19.2",
     "firebase-admin": "^12.0.0",

--- a/server.js
+++ b/server.js
@@ -6,10 +6,44 @@ const { v4: uuidv4, validate: uuidValidate } = require('uuid');
 const QRCode = require('qrcode');
 const { parseVideoId } = require('./parseVideoId');
 const { getFairQueue } = require('./fairPlay');
+const {
+  generateRegistration,
+  verifyRegistration,
+  generateAuth,
+  verifyAuth,
+} = require('./kjAuth');
 
 const app = express();
 app.use(bodyParser.json());
 app.use(express.static('public'));
+
+app.get('/auth/register/options', (req, res) => {
+  const opts = generateRegistration();
+  res.json(opts);
+});
+
+app.post('/auth/register/verify', async (req, res) => {
+  try {
+    const verified = await verifyRegistration(req.body);
+    res.json({ verified });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+app.get('/auth/login/options', (req, res) => {
+  const opts = generateAuth();
+  res.json(opts);
+});
+
+app.post('/auth/login/verify', async (req, res) => {
+  try {
+    const verified = await verifyAuth(req.body);
+    res.json({ verified });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
 
 const apiKey = process.env.YOUTUBE_API_KEY;
 if (!apiKey) {


### PR DESCRIPTION
## Summary
- implement KJ authentication using passkeys via `@simplewebauthn/server`
- add endpoints to register and login with a passkey
- update tasks checklist

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684879f6a7808325a115377e6b5d5f0d