### PR TITLE
Persist singer device IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,11 @@ current video and a list of upcoming singers.
 
 Endpoints:
 - `POST /sessions` – creates a new session and returns a room code and QR code.
-- `POST /sessions/:code/join` with `name` and optional `deviceId` – joins a
-  session. The `deviceId` must be a UUID and should be reused for the duration
-  of the session; if a different name is sent for an existing `deviceId`, the
-  server will reject the request.
+ - `POST /sessions/:code/join` with `name` and optional `deviceId` – joins a
+    session. The `deviceId` must be a UUID and should be reused for the duration
+    of the session; if a different name is sent for an existing `deviceId`, the
+    server will reject the request. Store this identifier in `localStorage` keyed
+    by session code so returning guests keep the same device ID.
 - `GET /search?q=term` – returns the top five karaoke results.
 - `POST /songs` with `videoId` or `url` and `singer` – adds a song to the queue
   (max three per singer).

--- a/Tasks.md
+++ b/Tasks.md
@@ -20,7 +20,7 @@ This checklist captures the work required to deliver the features outlined in **
 - [ ] Build a KJ control panel for reordering, removing, replacing, skipping, and pausing songs.
 
 ## Technical Tasks
-- [ ] Persist singer device IDs in localStorage keyed by session ID.
+- [x] Persist singer device IDs in localStorage keyed by session ID.
 - [x] Record playback failures in Firestore via an `error` field.
 - [x] Implement the `startSession` Cloud Function to pull prepared content from Drupal.
 - [ ] Document API contracts and data models in the BRD.

--- a/public/join.html
+++ b/public/join.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Join Session</title>
+  <style>
+    body { font-family: sans-serif; text-align: center; }
+  </style>
+</head>
+<body>
+  <h1>Join Karaoke Session</h1>
+  <input id="code" placeholder="Session Code">
+  <input id="name" placeholder="Your Name">
+  <button id="joinBtn">Join</button>
+  <pre id="status"></pre>
+  <script src="join.js"></script>
+  <script>
+    document.getElementById('joinBtn').onclick = async () => {
+      const code = document.getElementById('code').value.trim();
+      const name = document.getElementById('name').value.trim();
+      if (!code || !name) return;
+      try {
+        const result = await joinSession(code, name);
+        document.getElementById('status').textContent = `Joined as ${result.singerId}`;
+      } catch (err) {
+        document.getElementById('status').textContent = err.message;
+      }
+    };
+  </script>
+</body>
+</html>

--- a/public/join.js
+++ b/public/join.js
@@ -1,0 +1,16 @@
+async function joinSession(code, name) {
+  const key = 'karaoke-mn-id-' + code;
+  const storedId = localStorage.getItem(key);
+  const res = await fetch('/sessions/' + encodeURIComponent(code) + '/join', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, deviceId: storedId || undefined })
+  });
+  const data = await res.json();
+  if (res.ok) {
+    localStorage.setItem(key, data.deviceId);
+    return data;
+  } else {
+    throw new Error(data.error || 'Join failed');
+  }
+}


### PR DESCRIPTION
## Summary
- persist device IDs per session in browser localStorage
- add minimal join page using this persistence logic
- document localStorage requirement
- check off the Tasks item

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68487a650ca88325af5cd3cc4cf99e40