### PR TITLE
Add missing module tests

### DIFF
--- a/__tests__/firebase.test.js
+++ b/__tests__/firebase.test.js
@@ -1,0 +1,42 @@
+const admin = require('firebase-admin');
+
+jest.mock('firebase-admin', () => {
+  const firestore = jest.fn();
+  return {
+    apps: [],
+    initializeApp: jest.fn(),
+    credential: { cert: jest.fn(() => ({})) },
+    firestore,
+  };
+});
+
+describe('getFirestore', () => {
+  beforeEach(() => {
+    admin.apps.length = 0;
+    admin.initializeApp.mockClear();
+    admin.firestore.mockClear();
+    delete require.cache[require.resolve('../firebase')];
+  });
+
+  test('returns null when no credentials or emulator', () => {
+    delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    delete process.env.FIRESTORE_EMULATOR_HOST;
+
+    const { getFirestore } = require('../firebase');
+    const db = getFirestore();
+    expect(db).toBeNull();
+    expect(admin.initializeApp).not.toHaveBeenCalled();
+  });
+
+  test('initializes when emulator configured', () => {
+    delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    process.env.FIRESTORE_EMULATOR_HOST = 'localhost:8080';
+    const fakeDb = {};
+    admin.firestore.mockReturnValue(fakeDb);
+
+    const { getFirestore } = require('../firebase');
+    const db = getFirestore();
+    expect(admin.initializeApp).toHaveBeenCalledWith({});
+    expect(db).toBe(fakeDb);
+  });
+});

--- a/__tests__/kjAuth.test.js
+++ b/__tests__/kjAuth.test.js
@@ -1,0 +1,47 @@
+jest.mock('@simplewebauthn/server', () => ({
+  generateRegistrationOptions: jest.fn(() => ({ challenge: 'reg-challenge' })),
+  verifyRegistrationResponse: jest.fn(() => Promise.resolve({
+    verified: true,
+    registrationInfo: {
+      credentialPublicKey: 'pk',
+      credentialID: Buffer.from('dev'),
+      counter: 0,
+    },
+  })),
+  generateAuthenticationOptions: jest.fn(() => ({ challenge: 'auth-challenge' })),
+  verifyAuthenticationResponse: jest.fn(() => Promise.resolve({
+    verified: true,
+    authenticationInfo: { newCounter: 1 },
+  })),
+}));
+
+const server = require('@simplewebauthn/server');
+const { generateRegistration, verifyRegistration, generateAuth, verifyAuth } = require('../kjAuth');
+
+describe('kjAuth', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('registration and auth flow', async () => {
+    const regOpts = generateRegistration();
+    await verifyRegistration({});
+
+    expect(server.generateRegistrationOptions).toHaveBeenCalled();
+    expect(server.verifyRegistrationResponse).toHaveBeenCalledWith(expect.objectContaining({
+      expectedChallenge: regOpts.challenge,
+    }));
+
+    const authOpts = generateAuth();
+    expect(server.generateAuthenticationOptions).toHaveBeenCalledWith(expect.objectContaining({
+      allowCredentials: [expect.objectContaining({ id: expect.any(Buffer) })],
+    }));
+    const rawId = server.generateAuthenticationOptions.mock.calls[0][0].allowCredentials[0].id.toString('base64url');
+    await verifyAuth({ rawId });
+
+    expect(server.verifyAuthenticationResponse).toHaveBeenCalledWith(expect.objectContaining({
+      expectedChallenge: authOpts.challenge,
+      authenticator: expect.any(Object),
+    }));
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for Firebase initialization logic
- add tests for KJ passkey auth helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68487bba30d88325b82459c2614dd575