### PR TITLE
Add frontend taskmaster

### DIFF
--- a/frontend-tasks.md
+++ b/frontend-tasks.md
@@ -1,0 +1,30 @@
+# Frontend Taskmaster
+
+This checklist breaks down the work required to implement the Karaoke MN front-end using Lit.
+Each item is independent so multiple Codex sessions can work in parallel.
+
+## Build & Tooling
+- [ ] Install Lit and configure a modern build system (e.g. Vite) for component development.
+- [ ] Set up ESLint/Prettier for consistent styling.
+- [ ] Configure Jest with a browser environment for UI tests.
+
+## Core App Structure
+- [ ] Implement the `karaoke-app` root component with basic routing for KJ, Guest and Main views.
+
+## KJ Components
+- [ ] Create `kj-login` handling passkey authentication.
+- [ ] Build `kj-dashboard` as the container for KJ controls.
+- [ ] Implement `kj-session-creator` to start a session and display the room code/QR.
+- [ ] Implement `kj-control-panel` for queue management.
+
+## Guest Components
+- [ ] Create `guest-join-session` for entering room code and singer name.
+- [ ] Implement `guest-song-search` with `search-bar`, `search-results-list` and `search-result-item` subcomponents.
+- [ ] Build `guest-queue-view` showing a guest their queued songs.
+
+## Main Screen
+- [ ] Create `main-screen-view` hosting `youtube-player`, `main-queue-display` and `session-info-display`.
+
+## Shared Components
+- [ ] Implement reusable pieces: `qr-code-display`, `loading-spinner`, `modal-dialog` and `toast-notification`.
+


### PR DESCRIPTION
## Summary
- create `frontend-tasks.md` with parallelizable tasks for the Lit frontend

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848a927fa4c83259ec8806c8982af91