### PR TITLE
Implement KJ login and dashboard components

### DIFF
--- a/frontend-tasks.md
+++ b/frontend-tasks.md
@@ -15,10 +15,10 @@ Each item is independent so multiple Codex sessions can work in parallel.
 
 ## KJ Components
 
-- [ ] Create `kj-login` handling passkey authentication.
-- [ ] Build `kj-dashboard` as the container for KJ controls.
-- [ ] Implement `kj-session-creator` to start a session and display the room code/QR.
-- [ ] Implement `kj-control-panel` for queue management.
+- [x] Create `kj-login` handling passkey authentication.
+- [x] Build `kj-dashboard` as the container for KJ controls.
+- [x] Implement `kj-session-creator` to start a session and display the room code/QR.
+- [x] Implement `kj-control-panel` for queue management.
 
 ## Guest Components
 

--- a/frontend/karaoke-app.js
+++ b/frontend/karaoke-app.js
@@ -1,8 +1,25 @@
 import { LitElement, html, css } from 'lit';
+import './kj-login.js';
+import './kj-dashboard.js';
 
 class KJView extends LitElement {
+  static properties = {
+    loggedIn: { state: true },
+  };
+
+  constructor() {
+    super();
+    this.loggedIn = false;
+  }
+
+  _onLogin() {
+    this.loggedIn = true;
+  }
+
   render() {
-    return html`<div>KJ View</div>`;
+    return this.loggedIn
+      ? html`<kj-dashboard></kj-dashboard>`
+      : html`<kj-login @login=${this._onLogin}></kj-login>`;
   }
 }
 customElements.define('kj-view', KJView);

--- a/frontend/kj-control-panel.js
+++ b/frontend/kj-control-panel.js
@@ -1,0 +1,35 @@
+import { LitElement, html } from 'lit';
+
+export class KJControlPanel extends LitElement {
+  static properties = {
+    queue: { state: true },
+  };
+
+  constructor() {
+    super();
+    this.queue = [];
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._loadQueue();
+  }
+
+  async _loadQueue() {
+    const res = await fetch('/queue').then((r) => r.json());
+    this.queue = res.queue || [];
+  }
+
+  render() {
+    return html`
+      <h3>Queue</h3>
+      <ul>
+        ${this.queue.map(
+          (item) => html`<li>${item.singer}: ${item.videoId}</li>`,
+        )}
+      </ul>
+    `;
+  }
+}
+
+customElements.define('kj-control-panel', KJControlPanel);

--- a/frontend/kj-dashboard.js
+++ b/frontend/kj-dashboard.js
@@ -1,0 +1,14 @@
+import { LitElement, html } from 'lit';
+import './kj-session-creator.js';
+import './kj-control-panel.js';
+
+export class KJDashboard extends LitElement {
+  render() {
+    return html`
+      <kj-session-creator></kj-session-creator>
+      <kj-control-panel></kj-control-panel>
+    `;
+  }
+}
+
+customElements.define('kj-dashboard', KJDashboard);

--- a/frontend/kj-login.js
+++ b/frontend/kj-login.js
@@ -1,0 +1,67 @@
+import { LitElement, html } from 'lit';
+
+export class KJLogin extends LitElement {
+  static properties = {
+    loggedIn: { state: true },
+  };
+
+  constructor() {
+    super();
+    this.loggedIn = false;
+  }
+
+  async _register() {
+    try {
+      const opts = await fetch('/auth/register/options').then((r) => r.json());
+      const cred = await navigator.credentials.create({ publicKey: opts });
+      const res = await fetch('/auth/register/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(cred),
+      }).then((r) => r.json());
+      if (res.verified) {
+        this.loggedIn = true;
+        this.dispatchEvent(
+          new CustomEvent('login', { bubbles: true, composed: true }),
+        );
+      }
+    } catch (err) {
+      alert(err.message);
+    }
+  }
+
+  async _login() {
+    try {
+      const opts = await fetch('/auth/login/options').then((r) => r.json());
+      const cred = await navigator.credentials.get({ publicKey: opts });
+      const res = await fetch('/auth/login/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(cred),
+      }).then((r) => r.json());
+      if (res.verified) {
+        this.loggedIn = true;
+        this.dispatchEvent(
+          new CustomEvent('login', { bubbles: true, composed: true }),
+        );
+      } else {
+        alert('Authentication failed');
+      }
+    } catch (err) {
+      alert(err.message);
+    }
+  }
+
+  render() {
+    return html`
+      ${this.loggedIn
+        ? html`<p>Logged in as KJ</p>`
+        : html`
+            <button @click=${this._register}>Register Passkey</button>
+            <button @click=${this._login}>Login with Passkey</button>
+          `}
+    `;
+  }
+}
+
+customElements.define('kj-login', KJLogin);

--- a/frontend/kj-session-creator.js
+++ b/frontend/kj-session-creator.js
@@ -1,0 +1,41 @@
+import { LitElement, html } from 'lit';
+
+export class KJSessionCreator extends LitElement {
+  static properties = {
+    session: { state: true },
+  };
+
+  constructor() {
+    super();
+    this.session = null;
+  }
+
+  async _create() {
+    const res = await fetch('/sessions', { method: 'POST' }).then((r) =>
+      r.json(),
+    );
+    this.session = res;
+    this.dispatchEvent(
+      new CustomEvent('session-created', {
+        detail: res,
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  render() {
+    return html`
+      <div>
+        ${this.session
+          ? html`
+              <p>Room Code: ${this.session.code}</p>
+              <img src="${this.session.qrCode}" alt="QR Code" />
+            `
+          : html`<button @click=${this._create}>Start Session</button>`}
+      </div>
+    `;
+  }
+}
+
+customElements.define('kj-session-creator', KJSessionCreator);


### PR DESCRIPTION
## Summary
- create `kj-login` to handle passkey auth
- add `kj-dashboard`, `kj-session-creator`, and `kj-control-panel`
- wire new components into `karaoke-app`
- mark KJ tasks complete in `frontend-tasks.md`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848d5fe18a083259b4e208518caef00