### PR TITLE
Finish shared Lit components

### DIFF
--- a/frontend-tasks.md
+++ b/frontend-tasks.md
@@ -32,4 +32,4 @@ Each item is independent so multiple Codex sessions can work in parallel.
 
 ## Shared Components
 
-- [ ] Implement reusable pieces: `qr-code-display`, `loading-spinner`, `modal-dialog` and `toast-notification`.
+ - [x] Implement reusable pieces: `qr-code-display`, `loading-spinner`, `modal-dialog` and `toast-notification`.

--- a/frontend/guest-join-session.js
+++ b/frontend/guest-join-session.js
@@ -1,4 +1,5 @@
 import { LitElement, html, css } from 'lit';
+import './toast-notification.js';
 
 export class GuestJoinSession extends LitElement {
   static properties = {
@@ -22,6 +23,13 @@ export class GuestJoinSession extends LitElement {
     this.name = e.target.value;
   }
 
+  _showToast(msg) {
+    const toast = this.renderRoot?.getElementById('toast');
+    if (toast) {
+      toast.show(msg);
+    }
+  }
+
   async _join() {
     if (!this.code || !this.name) return;
     try {
@@ -42,6 +50,7 @@ export class GuestJoinSession extends LitElement {
       if (res.ok) {
         localStorage.setItem(key, data.deviceId);
         this.message = `Joined session as ${this.name}`;
+        this._showToast(this.message);
         this.dispatchEvent(
           new CustomEvent('session-joined', {
             detail: { ...data, code: this.code, name: this.name.trim() },
@@ -51,9 +60,11 @@ export class GuestJoinSession extends LitElement {
         );
       } else {
         this.message = data.error || 'Join failed';
+        this._showToast(this.message);
       }
     } catch (err) {
       this.message = err.message;
+      this._showToast(this.message);
     }
   }
 
@@ -87,9 +98,10 @@ export class GuestJoinSession extends LitElement {
           .value=${this.name}
           @input=${this._onNameInput}
         />
-        <button @click=${this._join}>Join</button>
+      <button @click=${this._join}>Join</button>
         ${this.message ? html`<p>${this.message}</p>` : ''}
       </div>
+      <toast-notification id="toast"></toast-notification>
     `;
   }
 }

--- a/frontend/guest-song-search.js
+++ b/frontend/guest-song-search.js
@@ -1,6 +1,7 @@
 import { LitElement, html, css } from 'lit';
 import './search-bar.js';
 import './search-results-list.js';
+import './loading-spinner.js';
 
 export class GuestSongSearch extends LitElement {
   static properties = {
@@ -52,7 +53,7 @@ export class GuestSongSearch extends LitElement {
     return html`
       <search-bar @search=${this._onSearch}></search-bar>
       ${this.loading
-        ? html`<p>Loading...</p>`
+        ? html`<loading-spinner></loading-spinner>`
         : html`<search-results-list
             .results=${this.results}
             @add-song=${this._addSong}

--- a/frontend/loading-spinner.js
+++ b/frontend/loading-spinner.js
@@ -1,0 +1,28 @@
+import { LitElement, html, css } from 'lit';
+
+export class LoadingSpinner extends LitElement {
+  static styles = css`
+    :host {
+      display: inline-block;
+    }
+    .spinner {
+      border: 4px solid rgba(255, 255, 255, 0.3);
+      border-top-color: #fff;
+      border-radius: 50%;
+      width: 24px;
+      height: 24px;
+      animation: spin 1s linear infinite;
+    }
+    @keyframes spin {
+      to {
+        transform: rotate(360deg);
+      }
+    }
+  `;
+
+  render() {
+    return html`<div class="spinner"></div>`;
+  }
+}
+
+customElements.define('loading-spinner', LoadingSpinner);

--- a/frontend/modal-dialog.js
+++ b/frontend/modal-dialog.js
@@ -1,0 +1,67 @@
+import { LitElement, html, css } from 'lit';
+
+export class ModalDialog extends LitElement {
+  static properties = {
+    open: { type: Boolean, reflect: true },
+  };
+
+  constructor() {
+    super();
+    this.open = false;
+  }
+
+  close() {
+    this.open = false;
+  }
+
+  _onBackdrop(e) {
+    if (e.target === e.currentTarget) {
+      this.close();
+    }
+  }
+
+  static styles = css`
+    :host {
+      display: none;
+    }
+    :host([open]) {
+      display: block;
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.6);
+      z-index: 1000;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .dialog {
+      background: #fff;
+      color: #000;
+      padding: 1rem;
+      border-radius: 4px;
+      max-width: 90%;
+      max-height: 90%;
+      overflow: auto;
+    }
+  `;
+
+  render() {
+    return html`
+      <div class="dialog" @click=${(e) => e.stopPropagation()}>
+        <slot></slot>
+      </div>
+    `;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.addEventListener('click', this._onBackdrop);
+  }
+
+  disconnectedCallback() {
+    this.removeEventListener('click', this._onBackdrop);
+    super.disconnectedCallback();
+  }
+}
+
+customElements.define('modal-dialog', ModalDialog);

--- a/frontend/toast-notification.js
+++ b/frontend/toast-notification.js
@@ -1,0 +1,53 @@
+import { LitElement, html, css } from 'lit';
+
+export class ToastNotification extends LitElement {
+  static properties = {
+    message: { type: String },
+    open: { type: Boolean, reflect: true },
+    duration: { type: Number },
+  };
+
+  constructor() {
+    super();
+    this.message = '';
+    this.open = false;
+    this.duration = 3000;
+    this._timer = null;
+  }
+
+  show(msg, duration = this.duration) {
+    this.message = msg;
+    this.open = true;
+    clearTimeout(this._timer);
+    this._timer = setTimeout(() => {
+      this.open = false;
+    }, duration);
+  }
+
+  static styles = css`
+    :host {
+      position: fixed;
+      left: 50%;
+      bottom: 1rem;
+      transform: translateX(-50%);
+      background: #323232;
+      color: #fff;
+      padding: 0.5rem 1rem;
+      border-radius: 4px;
+      opacity: 0;
+      transition: opacity 0.3s ease;
+      pointer-events: none;
+      z-index: 1000;
+    }
+    :host([open]) {
+      opacity: 1;
+      pointer-events: auto;
+    }
+  `;
+
+  render() {
+    return html`${this.message}`;
+  }
+}
+
+customElements.define('toast-notification', ToastNotification);


### PR DESCRIPTION
## Summary
- add `loading-spinner`, `modal-dialog`, and `toast-notification` Lit components
- use the spinner in `guest-song-search`
- show join messages with a toast in `guest-join-session`
- mark remaining frontend tasks as done

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848df90cea08325a7c2641d2b67f0f2