### PR TITLE
Implement routing and server fallback

### DIFF
--- a/frontend/karaoke-app.js
+++ b/frontend/karaoke-app.js
@@ -101,8 +101,8 @@ export class KaraokeApp extends LitElement {
 
   _getRoute() {
     const path = window.location.pathname;
-    if (path.startsWith('/kj')) return 'kj';
-    if (path.startsWith('/guest')) return 'guest';
+    if (path === '/' || path.startsWith('/guest')) return 'guest';
+    if (path.startsWith('/admin')) return 'kj';
     if (path.startsWith('/main')) return 'main';
     if (path.startsWith('/settings')) return 'settings';
     return 'guest';
@@ -136,8 +136,8 @@ export class KaraokeApp extends LitElement {
         ? html`<onboarding-flow @onboarding-complete=${this._handleOnboardingComplete}></onboarding-flow>`
         : html`
             <nav>
-              <a @click=${() => this._navigate('/kj')}>KJ</a>
-              <a @click=${() => this._navigate('/guest')}>Guest</a>
+              <a @click=${() => this._navigate('/admin')}>KJ</a>
+              <a @click=${() => this._navigate('/')}>Guest</a>
               <a @click=${() => this._navigate('/main')}>Main</a>
               <a @click=${() => this._navigate('/settings')}>Settings</a>
             </nav>

--- a/server.js
+++ b/server.js
@@ -374,9 +374,13 @@ app.get('/queue', (req, res) => {
   res.json({ paused, queue: ordered });
 });
 
-// Admin UI route
+// Admin UI routes served by the Lit app
+app.get('/admin/:id', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'dist', 'index.html'));
+});
+
 app.get('/admin', (req, res) => {
-  res.sendFile(path.join(__dirname, 'public', 'kj.html'));
+  res.sendFile(path.join(__dirname, 'public', 'dist', 'index.html'));
 });
 
 // Serve the Lit app from the Vite build output for all non-API, non-admin routes

--- a/tasks/tasks-prd-karafun-like-frontend.md
+++ b/tasks/tasks-prd-karafun-like-frontend.md
@@ -21,10 +21,10 @@
 
 ## Tasks
 
-- [ ] **1.0** Set up the Lit application and configure routing (`/`, `/admin`, `/admin/<uuid>`)
+- [x] **1.0** Set up the Lit application and configure routing (`/`, `/admin`, `/admin/<uuid>`)
   - [x] **1.1** Verify Vite outputs the build to `public/dist` and is served by `server.js`.
-  - [ ] **1.2** Implement routing logic in `karaoke-app.js` to load guest, KJ and main components.
-  - [ ] **1.3** Ensure unknown paths fall back to the Lit app from the server.
+  - [x] **1.2** Implement routing logic in `karaoke-app.js` to load guest, KJ and main components.
+  - [x] **1.3** Ensure unknown paths fall back to the Lit app from the server.
 - [ ] **2.0** Implement passkey authentication and guest session joining
   - [ ] **2.1** Add WebAuthn registration and login flows in `kj-login` using `kjAuth.js` endpoints.
   - [ ] **2.2** Display a QR code and room code on the main screen so guests can join.


### PR DESCRIPTION
## Summary
- configure Express to serve the Lit app for `/admin` and `/admin/:id`
- update `karaoke-app` routing logic for `/`, `/admin` and `/main`
- mark routing tasks as complete

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849cc0fd0a88325961d72de1c0945d7