### PR TITLE
Implement queue controls for KJ dashboard

### DIFF
--- a/__tests__/queueEndpoints.test.js
+++ b/__tests__/queueEndpoints.test.js
@@ -1,0 +1,52 @@
+import { describe, test, beforeEach, expect, vi } from 'vitest';
+import { TextEncoder, TextDecoder } from 'util';
+import request from 'supertest';
+
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+
+let app;
+
+beforeEach(async () => {
+  vi.resetModules();
+  process.env.YOUTUBE_API_KEY = 'test';
+  const mod = await import('../server.js');
+  app = mod.default || mod;
+});
+
+describe('queue endpoints', () => {
+  test('skip moves song out of queue', async () => {
+    const session = await request(app).post('/sessions');
+    const { code } = session.body;
+    await request(app).post(`/sessions/${code}/join`).send({ name: 'A' });
+    const add = await request(app)
+      .post('/songs')
+      .send({ videoId: 'VID1', singer: 'A' });
+    const id = add.body.id;
+
+    await request(app).post(`/songs/${id}/skip`);
+
+    const q = await request(app).get('/queue');
+    expect(q.body.queue.length).toBe(0);
+  });
+
+  test('reorder updates queue order', async () => {
+    const session = await request(app).post('/sessions');
+    const { code } = session.body;
+    await request(app).post(`/sessions/${code}/join`).send({ name: 'A' });
+
+    const res1 = await request(app)
+      .post('/songs')
+      .send({ videoId: 'AAAAAAAAAAA', singer: 'A' });
+    const res2 = await request(app)
+      .post('/songs')
+      .send({ videoId: 'BBBBBBBBBBB', singer: 'A' });
+
+    await request(app)
+      .post('/songs/reorder')
+      .send({ order: [res2.body.id, res1.body.id] });
+
+    const q = await request(app).get('/queue');
+    expect(q.body.queue.map((s) => s.id)).toEqual([res2.body.id, res1.body.id]);
+  });
+});

--- a/frontend/kj-control-panel.js
+++ b/frontend/kj-control-panel.js
@@ -1,18 +1,28 @@
-import { LitElement, html } from 'lit';
+import { LitElement, html, css } from 'lit';
 
 export class KJControlPanel extends LitElement {
   static properties = {
     queue: { state: true },
+    singer: { state: true },
+    videoId: { state: true },
   };
 
   constructor() {
     super();
     this.queue = [];
+    this.singer = '';
+    this.videoId = '';
   }
 
   connectedCallback() {
     super.connectedCallback();
     this._loadQueue();
+    this._interval = setInterval(() => this._loadQueue(), 5000);
+  }
+
+  disconnectedCallback() {
+    clearInterval(this._interval);
+    super.disconnectedCallback();
   }
 
   async _loadQueue() {
@@ -20,12 +30,93 @@ export class KJControlPanel extends LitElement {
     this.queue = res.queue || [];
   }
 
+  async _addSong() {
+    if (!this.singer || !this.videoId) return;
+    await fetch('/songs', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ videoId: this.videoId, singer: this.singer }),
+    });
+    this.videoId = '';
+    await this._loadQueue();
+  }
+
+  async _complete(id) {
+    await fetch(`/songs/${id}/complete`, { method: 'POST' });
+    await this._loadQueue();
+  }
+
+  async _skip(id) {
+    await fetch(`/songs/${id}/skip`, { method: 'POST' });
+    await this._loadQueue();
+  }
+
+  async _reorder(from, to) {
+    const newQueue = [...this.queue];
+    const [moved] = newQueue.splice(from, 1);
+    newQueue.splice(to, 0, moved);
+    await fetch('/songs/reorder', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ order: newQueue.map((s) => s.id) }),
+    });
+    await this._loadQueue();
+  }
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+    ul {
+      list-style: none;
+      padding: 0;
+    }
+    li {
+      display: flex;
+      gap: 0.5rem;
+      align-items: center;
+    }
+    input {
+      margin-right: 0.25rem;
+    }
+  `;
+
   render() {
     return html`
       <h3>Queue</h3>
+      <div>
+        <input
+          placeholder="Singer"
+          .value=${this.singer}
+          @input=${(e) => (this.singer = e.target.value)}
+        />
+        <input
+          placeholder="Video ID"
+          .value=${this.videoId}
+          @input=${(e) => (this.videoId = e.target.value)}
+        />
+        <button @click=${this._addSong}>Add</button>
+      </div>
       <ul>
         ${this.queue.map(
-          (item) => html`<li>${item.singer}: ${item.videoId}</li>`,
+          (item, index) =>
+            html`<li>
+              ${item.singer}: ${item.videoId}
+              <button
+                @click=${() => this._reorder(index, index - 1)}
+                disabled=${index === 0}
+              >
+                ↑
+              </button>
+              <button
+                @click=${() => this._reorder(index, index + 1)}
+                disabled=${index === this.queue.length - 1}
+              >
+                ↓
+              </button>
+              <button @click=${() => this._skip(item.id)}>Skip</button>
+              <button @click=${() => this._complete(item.id)}>Complete</button>
+            </li>`,
         )}
       </ul>
     `;

--- a/tasks/tasks-prd-karafun-like-frontend.md
+++ b/tasks/tasks-prd-karafun-like-frontend.md
@@ -34,7 +34,7 @@
   - [x] **3.2** Use `search-results-list` and `search-result-item` to display YouTube songs.
   - [x] **3.3** Allow previewing songs with the `/preview` endpoint before queueing.
 - [ ] **4.0** Create the KJ dashboard with queue management using `fairPlay.js`
-  - [ ] **4.1** Implement add, reorder, skip and complete actions in `kj-control-panel`.
+  - [x] **4.1** Implement add, reorder, skip and complete actions in `kj-control-panel`.
   - [ ] **4.2** Use `fairPlay.js` to order songs returned from `/queue`.
   - [ ] **4.3** Write Vitest unit tests covering queue logic and KJ endpoints.
 - [ ] **5.0** Design the main screen showing upcoming singers and content


### PR DESCRIPTION
## Summary
- implement queue management actions in `kj-control-panel`
- mark related task complete
- add tests for queue endpoints

## Testing
- `npm install`
- `npm test`
- `npm run lint`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6849d260a66883259463f824406dd217