### PR TITLE
Fix passkey flow and update tests

### DIFF
--- a/__tests__/kjAuth.test.js
+++ b/__tests__/kjAuth.test.js
@@ -25,7 +25,7 @@ describe('kjAuth', () => {
   });
 
   test('registration and auth flow', async () => {
-    const regOpts = generateRegistration();
+    const regOpts = await generateRegistration();
     await verifyRegistration({});
 
     expect(server.generateRegistrationOptions).toHaveBeenCalled();
@@ -33,7 +33,7 @@ describe('kjAuth', () => {
       expectedChallenge: regOpts.challenge,
     }));
 
-    const authOpts = generateAuth();
+    const authOpts = await generateAuth();
     expect(server.generateAuthenticationOptions).toHaveBeenCalledWith(expect.objectContaining({
       allowCredentials: [expect.objectContaining({ id: expect.any(Buffer) })],
     }));

--- a/frontend/kj-login.test.js
+++ b/frontend/kj-login.test.js
@@ -1,0 +1,53 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, beforeEach, test, expect, vi } from 'vitest';
+import './kj-login.js';
+
+function flush() {
+  return new Promise((r) => setTimeout(r, 0));
+}
+
+describe('kj-login component', () => {
+  let element;
+  beforeEach(async () => {
+    document.body.innerHTML = '';
+    global.fetch = vi.fn();
+    global.navigator = { credentials: { create: vi.fn(), get: vi.fn() } };
+    element = document.createElement('kj-login');
+    document.body.appendChild(element);
+    await element.updateComplete;
+  });
+
+  test('register button triggers registration flow', async () => {
+    const loginSpy = vi.fn();
+    element.addEventListener('login', loginSpy);
+    fetch.mockResolvedValueOnce({ json: () => Promise.resolve({}) });
+    fetch.mockResolvedValueOnce({ json: () => Promise.resolve({ verified: true }) });
+    navigator.credentials.create.mockResolvedValue({});
+    const [regBtn] = element.shadowRoot.querySelectorAll('button');
+    regBtn.click();
+    await flush();
+    expect(navigator.credentials.create).toHaveBeenCalled();
+    expect(fetch.mock.calls[0][0]).toBe('/auth/register/options');
+    expect(fetch.mock.calls[1][0]).toBe('/auth/register/verify');
+    expect(loginSpy).toHaveBeenCalled();
+    expect(element.loggedIn).toBe(true);
+  });
+
+  test('login button triggers authentication flow', async () => {
+    const loginSpy = vi.fn();
+    element.addEventListener('login', loginSpy);
+    fetch.mockResolvedValueOnce({ json: () => Promise.resolve({}) });
+    fetch.mockResolvedValueOnce({ json: () => Promise.resolve({ verified: true }) });
+    navigator.credentials.get.mockResolvedValue({});
+    const [, loginBtn] = element.shadowRoot.querySelectorAll('button');
+    loginBtn.click();
+    await flush();
+    expect(navigator.credentials.get).toHaveBeenCalled();
+    expect(fetch.mock.calls[0][0]).toBe('/auth/login/options');
+    expect(fetch.mock.calls[1][0]).toBe('/auth/login/verify');
+    expect(loginSpy).toHaveBeenCalled();
+    expect(element.loggedIn).toBe(true);
+  });
+});

--- a/kjAuth.js
+++ b/kjAuth.js
@@ -10,7 +10,8 @@ const origin = process.env.ORIGIN || `http://${rpID}:3000`;
 const rpName = 'Karaoke MN';
 
 const kjUser = {
-  id: 'kj',
+  // Use a binary ID per simplewebauthn requirements
+  id: Buffer.from('kj'),
   username: 'KJ',
   devices: [],
   currentChallenge: null,
@@ -25,9 +26,9 @@ function getUserDevice(rawId) {
   return kjUser.devices.find((dev) => dev.credentialID.equals(idBuffer));
 }
 
-export function generateRegistration() {
+export async function generateRegistration() {
   const user = getUser();
-  const opts = generateRegistrationOptions({
+  const opts = await generateRegistrationOptions({
     rpName,
     rpID,
     userID: user.id,
@@ -56,9 +57,9 @@ export async function verifyRegistration(credential) {
   return verification.verified;
 }
 
-export function generateAuth() {
+export async function generateAuth() {
   const user = getUser();
-  const opts = generateAuthenticationOptions({
+  const opts = await generateAuthenticationOptions({
     rpID,
     userVerification: 'preferred',
     allowCredentials: user.devices.map((d) => ({ id: d.credentialID, type: 'public-key' })),

--- a/server.js
+++ b/server.js
@@ -31,8 +31,8 @@ app.use(express.static(path.join(__dirname, 'public', 'dist')));
 // Serve legacy/admin static files
 app.use(express.static(path.join(__dirname, 'public')));
 
-app.get('/auth/register/options', (req, res) => {
-  const opts = generateRegistration();
+app.get('/auth/register/options', async (req, res) => {
+  const opts = await generateRegistration();
   res.json(opts);
 });
 
@@ -45,8 +45,8 @@ app.post('/auth/register/verify', async (req, res) => {
   }
 });
 
-app.get('/auth/login/options', (req, res) => {
-  const opts = generateAuth();
+app.get('/auth/login/options', async (req, res) => {
+  const opts = await generateAuth();
   res.json(opts);
 });
 

--- a/tasks/tasks-prd-karafun-like-frontend.md
+++ b/tasks/tasks-prd-karafun-like-frontend.md
@@ -37,6 +37,10 @@
   - [x] **4.1** Implement add, reorder, skip and complete actions in `kj-control-panel`.
   - [x] **4.2** Use `fairPlay.js` to order songs returned from `/queue`.
   - [ ] **4.3** Write Vitest unit tests covering queue logic and KJ endpoints.
+  - [ ] **4.4** Test `kj-login` to ensure the Register and Login buttons invoke
+        passkey APIs successfully.
+  - [ ] **4.5** Serve the KJ dashboard at `/admin` when authenticated.
+  - [ ] **4.6** Print the `/admin/<uuid>` link to the console on server start.
 - [ ] **5.0** Design the main screen showing upcoming singers and content
   - [ ] **5.1** Display at least the next five singers in `main-queue-display`.
   - [ ] **5.2** Load session content from Firestore and Drupal when available.

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -3,6 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['__tests__/**/*.test.js'],
+    include: ['__tests__/**/*.test.js', 'frontend/**/*.test.js'],
   },
 });


### PR DESCRIPTION
## Summary
- fix passkey registration/authentication by awaiting simplewebauthn helpers
- store KJ user ID as a Buffer
- adjust server routes to await async auth functions
- update unit tests and component tests for async changes

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849d502742c8325a02fb099088ae065