### PR TITLE
Add passkey E2E test

### DIFF
--- a/e2e/main-screen.spec.js
+++ b/e2e/main-screen.spec.js
@@ -1,19 +1,34 @@
 import { test, expect } from '@playwright/test';
+import { startServer } from './utils.js';
+
+let server;
+
+test.beforeEach(async () => {
+  const started = startServer();
+  server = started.server;
+  await started.ready;
+});
+
+test.afterEach(() => {
+  server?.kill();
+});
 
 test.describe('Main User-Facing UI', () => {
   test('should load and display the main navigation and guest join form', async ({ page }) => {
     await page.goto('/');
-    // Wait for karaoke-app to be present in the DOM
+    const gotIt = page.getByRole('button', { name: 'Got It!' });
+    if (await gotIt.isVisible().catch(() => false)) {
+      await gotIt.click();
+    }
     await page.waitForSelector('karaoke-app', { timeout: 10000 });
-    // Check for navigation bar and links
     await expect(page.locator('nav')).toHaveCount(1);
     await expect(page.getByText('KJ')).toBeVisible();
     await expect(page.getByText('Guest')).toBeVisible();
     await expect(page.getByText('Main')).toBeVisible();
-    // Check for guest-join-session form (default route)
     await expect(page.locator('guest-join-session')).toHaveCount(1);
     await expect(page.getByPlaceholder('Room Code')).toBeVisible();
     await expect(page.getByPlaceholder('Your Name')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Join session' })).toBeVisible();
   });
-}); 
+});
+

--- a/e2e/passkey-login.spec.js
+++ b/e2e/passkey-login.spec.js
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+import { startServer } from './utils.js';
+
+let server;
+let adminUrl;
+
+test.beforeEach(async () => {
+  const started = startServer();
+  server = started.server;
+  adminUrl = await started.ready;
+});
+
+test.afterEach(() => {
+  server?.kill();
+});
+
+test('register and login with passkey', async ({ page, context }) => {
+  const cdp = await context.newCDPSession(page);
+  await cdp.send('WebAuthn.enable');
+  const { authenticatorId } = await cdp.send('WebAuthn.addVirtualAuthenticator', {
+    options: { protocol: 'ctap2', transport: 'usb', hasResidentKey: true, hasUserVerification: true },
+  });
+
+  await page.goto(adminUrl);
+  const gotIt = page.getByRole('button', { name: 'Got It!' });
+  if (await gotIt.isVisible().catch(() => false)) {
+    await gotIt.click();
+  }
+  await page.getByRole('button', { name: 'Register Passkey' }).click();
+  await expect(page.getByText('Logged in as KJ')).toBeVisible();
+
+  await page.reload();
+  await page.getByRole('button', { name: 'Login with Passkey' }).click();
+  await expect(page.getByText('Logged in as KJ')).toBeVisible();
+
+  await cdp.send('WebAuthn.removeVirtualAuthenticator', { authenticatorId });
+});
+

--- a/e2e/utils.js
+++ b/e2e/utils.js
@@ -1,0 +1,23 @@
+import { spawn } from 'child_process';
+import { randomUUID } from 'crypto';
+
+export function startServer() {
+  const adminId = randomUUID();
+  const server = spawn('node', ['server.js'], {
+    env: { ...process.env, YOUTUBE_API_KEY: 'test', ADMIN_UUID: adminId },
+    stdio: ['ignore', 'pipe', 'inherit'],
+  });
+  const ready = new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('Server start timeout')), 10000);
+    server.stdout.on('data', (data) => {
+      const msg = data.toString();
+      const match = msg.match(/KJ registration link: (.*)/);
+      if (match) {
+        clearTimeout(timer);
+        resolve(match[1].trim());
+      }
+    });
+  });
+  return { server, ready };
+}
+

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -3,10 +3,12 @@
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 const config = {
   testDir: 'e2e',
+  workers: 1,
   use: {
     baseURL: 'http://localhost:3000/',
     headless: true,
   },
 };
 
-export default config; 
+export default config;
+


### PR DESCRIPTION
## Summary
- add helper to spin up the server for tests
- update main screen E2E test to launch the server and dismiss onboarding
- add new Playwright test covering passkey registration and login
- configure Playwright to run tests serially

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e` *(fails: Timed out waiting for passkey flow)*

------
https://chatgpt.com/codex/tasks/task_e_6849df10c4648325806015a9eb6f2f5f