### PR TITLE
Fix passkey server verification

### DIFF
--- a/__tests__/kjAuth.test.js
+++ b/__tests__/kjAuth.test.js
@@ -26,11 +26,13 @@ describe('kjAuth', () => {
 
   test('registration and auth flow', async () => {
     const regOpts = await generateRegistration();
-    await verifyRegistration({});
+    const regCred = { rawId: 'test' };
+    await verifyRegistration(regCred);
 
     expect(server.generateRegistrationOptions).toHaveBeenCalled();
     expect(server.verifyRegistrationResponse).toHaveBeenCalledWith(expect.objectContaining({
       expectedChallenge: regOpts.challenge,
+      response: regCred,
     }));
 
     const authOpts = await generateAuth();
@@ -38,10 +40,12 @@ describe('kjAuth', () => {
       allowCredentials: [expect.objectContaining({ id: expect.any(Buffer) })],
     }));
     const rawId = server.generateAuthenticationOptions.mock.calls[0][0].allowCredentials[0].id.toString('base64url');
-    await verifyAuth({ rawId });
+    const authCred = { rawId };
+    await verifyAuth(authCred);
 
     expect(server.verifyAuthenticationResponse).toHaveBeenCalledWith(expect.objectContaining({
       expectedChallenge: authOpts.challenge,
+      response: authCred,
       authenticator: expect.any(Object),
     }));
   });

--- a/e2e/passkey-login.spec.js
+++ b/e2e/passkey-login.spec.js
@@ -47,11 +47,15 @@ test('register and login with passkey', async ({ page, context }) => {
   
   // Add a longer timeout and wait for network idle
   await page.waitForLoadState('networkidle');
-  await expect(page.getByText('Logged in as KJ')).toBeVisible({ timeout: 10000 });
+  await expect(
+    page.getByRole('button', { name: 'Start a new karaoke session' })
+  ).toBeVisible({ timeout: 10000 });
 
   await page.reload();
   await page.getByRole('button', { name: 'Login with Passkey' }).click();
-  await expect(page.getByText('Logged in as KJ')).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: 'Start a new karaoke session' })
+  ).toBeVisible();
 
   await cdp.send('WebAuthn.removeVirtualAuthenticator', { authenticatorId });
 });

--- a/e2e/utils.js
+++ b/e2e/utils.js
@@ -1,7 +1,11 @@
-import { spawn } from 'child_process';
+import { spawn, spawnSync } from 'child_process';
 import { randomUUID } from 'crypto';
+import { existsSync } from 'fs';
 
 export function startServer() {
+  if (!existsSync('public/dist/index.html')) {
+    spawnSync('npm', ['run', 'build'], { stdio: 'inherit' });
+  }
   const adminId = randomUUID();
   const server = spawn('node', ['server.js'], {
     env: { ...process.env, YOUTUBE_API_KEY: 'test', ADMIN_UUID: adminId },

--- a/kjAuth.js
+++ b/kjAuth.js
@@ -50,7 +50,7 @@ export async function generateRegistration() {
 export async function verifyRegistration(credential) {
   const user = getUser();
   const verification = await verifyRegistrationResponse({
-    credential,
+    response: credential,
     expectedChallenge: user.currentChallenge,
     expectedOrigin: origin,
     expectedRPID: rpID,
@@ -78,7 +78,7 @@ export async function verifyAuth(credential) {
   const user = getUser();
   const device = getUserDevice(credential.rawId);
   const verification = await verifyAuthenticationResponse({
-    credential,
+    response: credential,
     expectedChallenge: user.currentChallenge,
     expectedOrigin: origin,
     expectedRPID: rpID,


### PR DESCRIPTION
## Summary
- pass correct param names to simplewebauthn verify functions
- update unit tests to assert proper params
- adjust e2e test to look for Start Session button
- build frontend automatically before e2e tests

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e` *(fails: element not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f847d5448325bc8f04a917b6ec09