### PR TITLE
Fix passkey flow and clarify E2E build

### DIFF
--- a/__tests__/kjAuth.test.js
+++ b/__tests__/kjAuth.test.js
@@ -4,9 +4,11 @@ vi.mock('@simplewebauthn/server', () => ({
   verifyRegistrationResponse: vi.fn(() => Promise.resolve({
     verified: true,
     registrationInfo: {
-      credentialPublicKey: 'pk',
-      credentialID: Buffer.from('dev'),
-      counter: 0,
+      credential: {
+        publicKey: 'pk',
+        id: 'ZGV2',
+        counter: 0,
+      },
     },
   })),
   generateAuthenticationOptions: vi.fn(() => ({ challenge: 'auth-challenge' })),
@@ -37,16 +39,18 @@ describe('kjAuth', () => {
 
     const authOpts = await generateAuth();
     expect(server.generateAuthenticationOptions).toHaveBeenCalledWith(expect.objectContaining({
-      allowCredentials: [expect.objectContaining({ id: expect.any(Buffer) })],
+      allowCredentials: [expect.objectContaining({ id: expect.any(String) })],
     }));
-    const rawId = server.generateAuthenticationOptions.mock.calls[0][0].allowCredentials[0].id.toString('base64url');
+    const rawId = server.generateAuthenticationOptions.mock.calls[0][0].allowCredentials[0].id;
     const authCred = { rawId };
     await verifyAuth(authCred);
 
-    expect(server.verifyAuthenticationResponse).toHaveBeenCalledWith(expect.objectContaining({
-      expectedChallenge: authOpts.challenge,
-      response: authCred,
-      authenticator: expect.any(Object),
-    }));
+    expect(server.verifyAuthenticationResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedChallenge: authOpts.challenge,
+        response: authCred,
+        credential: expect.any(Object),
+      }),
+    );
   });
 });

--- a/e2e/utils.js
+++ b/e2e/utils.js
@@ -4,6 +4,7 @@ import { existsSync } from 'fs';
 
 export function startServer() {
   if (!existsSync('public/dist/index.html')) {
+    console.log('Building frontend for E2E tests...');
     spawnSync('npm', ['run', 'build'], { stdio: 'inherit' });
   }
   const adminId = randomUUID();

--- a/server.js
+++ b/server.js
@@ -57,9 +57,11 @@ app.get('/auth/login/options', async (req, res) => {
 
 app.post('/auth/login/verify', async (req, res) => {
   try {
+    console.log('Login verification request:', JSON.stringify(req.body));
     const verified = await verifyAuth(req.body);
     res.json({ verified });
   } catch (err) {
+    console.error('Authentication verification error:', err.message);
     res.status(400).json({ error: err.message });
   }
 });


### PR DESCRIPTION
## Summary
- serialize WebAuthn responses for registration and login
- store credential info returned from simplewebauthn
- pass stored credential as `credential` when verifying authentication
- log incoming auth requests for easier debugging
- log when E2E tests build the frontend

## Testing
- `npm run lint`
- `npm test`
- `rm -rf public/dist && npm run build`
- `npm run test:e2e` *(fails: browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a0beb20b4832599e850f68154a55e