### PR TITLE
Update tasks and convert scripts to ESM

### DIFF
--- a/frontend-tasks.md
+++ b/frontend-tasks.md
@@ -48,11 +48,11 @@ Each item is independent so multiple Codex sessions can work in parallel.
 
 ## User Experience Enhancements
 
-- [ ] Implement a settings/profile screen for KJ and guests (theme, preferences, etc.).
+- [x] Implement a settings/profile screen for KJ and guests (theme, preferences, etc.).
 - [x] Add onboarding/tutorial flow for first-time users (skippable, highlights main features).
 - [ ] Add analytics/stats display (e.g., most popular songs, top singers, session summary).
 - [ ] Implement error/offline handling screens and banners for network or backend issues.
 
 ## Authentication & Passkeys
 
-- [ ] Resolve error during passkey creation: "Failed to execute 'create' on 'CredentialsContainer': Failed to read the 'publicKey' property from 'CredentialCreationOptions': Failed to read the 'challenge' property from 'PublicKeyCredentialCreationOptions': Required member is undefined."
+- [x] Resolve error during passkey creation: "Failed to execute 'create' on 'CredentialsContainer': Failed to read the 'publicKey' property from 'CredentialCreationOptions': Failed to read the 'challenge' property from 'PublicKeyCredentialCreationOptions': Required member is undefined."

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,11 +1,11 @@
-const functions = require('firebase-functions');
-const admin = require('firebase-admin');
+import * as functions from 'firebase-functions';
+import admin from 'firebase-admin';
 
 if (admin.apps.length === 0) {
   admin.initializeApp();
 }
 
-exports.startSession = functions.https.onCall(async (data, context) => {
+export const startSession = functions.https.onCall(async (data, context) => {
   const drupalUrl = process.env.DRUPAL_CONTENT_URL;
   if (!drupalUrl) {
     throw new functions.https.HttpsError(

--- a/search.js
+++ b/search.js
@@ -1,5 +1,6 @@
-require('dotenv').config();
-const {google} = require('googleapis');
+import dotenv from 'dotenv';
+dotenv.config();
+import { google } from 'googleapis';
 const query = process.argv.slice(2).join(' ');
 
 if (!query) {


### PR DESCRIPTION
## Summary
- note completed settings/profile screen
- update passkey error task
- convert `search.js` and `functions/index.js` to ESM

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ad90a9af48325805ae6ac0a9caf4c