### PR TITLE
Clean up start script duplicate admin link code

### DIFF
--- a/start.js
+++ b/start.js
@@ -41,8 +41,6 @@ async function startApp() {
     if (msg.includes('Server running on port')) {
       const portMatch = msg.match(/port (\d+)/);
       const detectedPort = portMatch ? portMatch[1] : '3000';
-      const link = `http://localhost:${detectedPort}/admin/${adminId}`;
-      //console.log(`KJ registration link: ${link}`);
       await openBrowser(detectedPort, adminId);
     }
   });

--- a/tasks/tasks-prd-karafun-like-frontend.md
+++ b/tasks/tasks-prd-karafun-like-frontend.md
@@ -40,7 +40,7 @@
   - [ ] **4.4** Test `kj-login` to ensure the Register and Login buttons invoke
         passkey APIs successfully.
   - [ ] **4.5** Serve the KJ dashboard at `/admin` when authenticated.
-  - [ ] **4.6** Print the `/admin/<uuid>` link to the console on server start.
+  - [x] **4.6** Print the `/admin/<uuid>` link to the console on server start.
 - [ ] **5.0** Design the main screen showing upcoming singers and content
   - [ ] **5.1** Display at least the next five singers in `main-queue-display`.
   - [ ] **5.2** Load session content from Firestore and Drupal when available.


### PR DESCRIPTION
## Summary
- remove commented admin link logic from start script

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ada161e188325b85f936277787880