### PR TITLE
Implement admin dashboard auth persistence

### DIFF
--- a/frontend/karaoke-app.js
+++ b/frontend/karaoke-app.js
@@ -16,11 +16,12 @@ class KJView extends LitElement {
 
   constructor() {
     super();
-    this.loggedIn = false;
+    this.loggedIn = localStorage.getItem('kjLoggedIn') === 'true';
   }
 
   _onLogin() {
     this.loggedIn = true;
+    localStorage.setItem('kjLoggedIn', 'true');
   }
 
   render() {

--- a/frontend/kj-login.js
+++ b/frontend/kj-login.js
@@ -93,7 +93,7 @@ export class KJLogin extends LitElement {
 
   constructor() {
     super();
-    this.loggedIn = false;
+    this.loggedIn = localStorage.getItem('kjLoggedIn') === 'true';
   }
 
   async _register() {
@@ -118,6 +118,7 @@ export class KJLogin extends LitElement {
       if (res.verified) {
         console.log('Registration verified successfully');
         this.loggedIn = true;
+        localStorage.setItem('kjLoggedIn', 'true');
         this.dispatchEvent(
           new CustomEvent('login', { bubbles: true, composed: true }),
         );
@@ -144,6 +145,7 @@ export class KJLogin extends LitElement {
       }).then((r) => r.json());
       if (res.verified) {
         this.loggedIn = true;
+        localStorage.setItem('kjLoggedIn', 'true');
         this.dispatchEvent(
           new CustomEvent('login', { bubbles: true, composed: true }),
         );

--- a/frontend/kj-login.test.js
+++ b/frontend/kj-login.test.js
@@ -14,6 +14,7 @@ describe('kj-login component', () => {
     document.body.innerHTML = '';
     global.fetch = vi.fn();
     global.navigator = { credentials: { create: vi.fn(), get: vi.fn() } };
+    localStorage.clear();
     element = document.createElement('kj-login');
     document.body.appendChild(element);
     await element.updateComplete;

--- a/tasks/tasks-prd-karafun-like-frontend.md
+++ b/tasks/tasks-prd-karafun-like-frontend.md
@@ -39,7 +39,7 @@
   - [x] **4.3** Write Vitest unit tests covering queue logic and KJ endpoints.
   - [x] **4.4** Test `kj-login` to ensure the Register and Login buttons invoke
         passkey APIs successfully.
-  - [ ] **4.5** Serve the KJ dashboard at `/admin` when authenticated.
+  - [x] **4.5** Serve the KJ dashboard at `/admin` when authenticated.
   - [x] **4.6** Print the `/admin/<uuid>` link to the console on server start.
 - [ ] **5.0** Design the main screen showing upcoming singers and content
   - [ ] **5.1** Display at least the next five singers in `main-queue-display`.


### PR DESCRIPTION
## Summary
- mark dashboard-serving task completed
- remember admin login using localStorage
- update admin login tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684af507e33c83259fa31f277466004f