### PR TITLE
Implement prepared content load and update tasks

### DIFF
--- a/__tests__/sessionsEndpoints.test.js
+++ b/__tests__/sessionsEndpoints.test.js
@@ -1,0 +1,37 @@
+import { describe, test, beforeEach, expect, vi } from 'vitest';
+import { TextEncoder, TextDecoder } from 'util';
+import request from 'supertest';
+
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+
+let app;
+
+const sessionData = { code: 'PURPLE-RAIN', preparedContent: { msg: 'hi' }, createdAt: Date.now() };
+const mockDb = {
+  collection: vi.fn(() => ({
+    doc: vi.fn(() => ({ set: vi.fn() })),
+    orderBy: vi.fn(() => ({
+      limit: vi.fn(() => ({
+        get: vi.fn(() => Promise.resolve({ empty: false, docs: [{ id: 'abc', data: () => sessionData }] }))
+      }))
+    }))
+  }))
+};
+
+vi.mock('../firebase.js', () => ({ getFirestore: () => mockDb }));
+
+beforeEach(async () => {
+  vi.resetModules();
+  process.env.YOUTUBE_API_KEY = 'test';
+  const mod = await import('../server.js');
+  app = mod.default || mod;
+});
+
+describe('sessions endpoints', () => {
+  test('current session loads from Firestore', async () => {
+    const res = await request(app).get('/sessions/current');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.preparedContent).toEqual(sessionData.preparedContent);
+  });
+});

--- a/tasks/tasks-prd-karafun-like-frontend.md
+++ b/tasks/tasks-prd-karafun-like-frontend.md
@@ -42,7 +42,7 @@
   - [x] **4.5** Serve the KJ dashboard at `/admin` when authenticated.
   - [x] **4.6** Print the `/admin/<uuid>` link to the console on server start.
 - [ ] **5.0** Design the main screen showing upcoming singers and content
-  - [ ] **5.1** Display at least the next five singers in `main-queue-display`.
+- [x] **5.1** Display at least the next five singers in `main-queue-display`.
   - [ ] **5.2** Load session content from Firestore and Drupal when available.
   - [ ] **5.3** Ensure layouts are responsive across phones, tablets and desktops.
 - [ ] **6.0** Switch the repository to Vitest for all testing


### PR DESCRIPTION
## Summary
- load prepared session content from Firestore when `GET /sessions/current` is called
- timestamp sessions when created
- mark main queue display task complete
- add tests for sessions endpoint

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e` *(fails: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b0516b5048325845a2b10d73970b3