### PR TITLE
Implement prepared content display

### DIFF
--- a/frontend/main-screen-view.js
+++ b/frontend/main-screen-view.js
@@ -4,6 +4,7 @@ import './main-queue-display.js';
 import './interstitial-player.js';
 import './on-screen-announcement.js';
 import './session-info-display.js';
+import './prepared-content-display.js';
 
 export class MainScreenView extends LitElement {
   static properties = {
@@ -52,13 +53,6 @@ export class MainScreenView extends LitElement {
       display: block;
       text-align: center;
     }
-    #prepared {
-      text-align: left;
-      margin: 1rem auto;
-      max-width: 600px;
-      background: #f5f5f5;
-      padding: 0.5rem;
-    }
   `;
 
   render() {
@@ -72,13 +66,9 @@ export class MainScreenView extends LitElement {
         .qrCode=${this.qrCode}
       ></session-info-display>
       <main-queue-display .queue=${this.queue.slice(1, 6)}></main-queue-display>
-      ${this.preparedContent
-        ? html`<pre id="prepared">${JSON.stringify(
-            this.preparedContent,
-            null,
-            2,
-          )}</pre>`
-        : ''}
+      <prepared-content-display
+        .content=${this.preparedContent}
+      ></prepared-content-display>
       <interstitial-player id="interstitial"></interstitial-player>
       <on-screen-announcement id="announcement"></on-screen-announcement>
     `;

--- a/frontend/prepared-content-display.js
+++ b/frontend/prepared-content-display.js
@@ -1,0 +1,38 @@
+import { LitElement, html, css } from 'lit';
+
+export class PreparedContentDisplay extends LitElement {
+  static properties = {
+    content: { type: Object },
+  };
+
+  constructor() {
+    super();
+    this.content = null;
+  }
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+    .wrapper {
+      text-align: left;
+      margin: 1rem auto;
+      max-width: 600px;
+      background: #fafafa;
+      padding: 0.5rem;
+      border-radius: 4px;
+    }
+  `;
+
+  render() {
+    if (!this.content) return html``;
+    return html`
+      <div class="wrapper">
+        <h3>Session Content</h3>
+        <pre>${JSON.stringify(this.content, null, 2)}</pre>
+      </div>
+    `;
+  }
+}
+
+customElements.define('prepared-content-display', PreparedContentDisplay);

--- a/tasks/tasks-prd-karafun-like-frontend.md
+++ b/tasks/tasks-prd-karafun-like-frontend.md
@@ -43,7 +43,7 @@
   - [x] **4.6** Print the `/admin/<uuid>` link to the console on server start.
 - [ ] **5.0** Design the main screen showing upcoming singers and content
 - [x] **5.1** Display at least the next five singers in `main-queue-display`.
-  - [ ] **5.2** Load session content from Firestore and Drupal when available.
+  - [x] **5.2** Load session content from Firestore and Drupal when available.
   - [ ] **5.3** Ensure layouts are responsive across phones, tablets and desktops.
 - [ ] **6.0** Switch the repository to Vitest for all testing
   - [ ] **6.1** Remove Jest dependencies and config files.


### PR DESCRIPTION
## Summary
- add a `prepared-content-display` component
- show prepared content on the main screen
- mark task 5.2 as complete

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b0c3152d88325a74085f7040d8d82