### PR TITLE
Complete task 5.0 - main screen styling

### DIFF
--- a/frontend/app-theme.js
+++ b/frontend/app-theme.js
@@ -1,0 +1,24 @@
+const style = document.createElement('style');
+style.textContent = `
+  :root {
+    --bg-color: #111;
+    --text-color: #fff;
+    --accent-color: #ff4081;
+    --surface-color: #222;
+  }
+  body {
+    margin: 0;
+    background: var(--bg-color);
+    color: var(--text-color);
+    font-family: Arial, Helvetica, sans-serif;
+  }
+  button {
+    background: var(--accent-color);
+    color: var(--text-color);
+    border: none;
+    padding: 0.5rem 1rem;
+    font-size: 1rem;
+    border-radius: 4px;
+  }
+`;
+document.head.appendChild(style);

--- a/frontend/main-queue-display.js
+++ b/frontend/main-queue-display.js
@@ -1,4 +1,5 @@
 import { LitElement, html, css } from 'lit';
+import './main-queue-item.js';
 
 export class MainQueueDisplay extends LitElement {
   static properties = {
@@ -11,16 +12,16 @@ export class MainQueueDisplay extends LitElement {
   }
 
   static styles = css`
-    ul {
+    :host {
+      display: block;
+      background: var(--surface-color, #222);
+      padding: 0.5rem;
+      border-radius: 4px;
+    }
+    .list {
       list-style: none;
       padding: 0;
-    }
-    li {
-      margin: 0.25rem 0;
-      font-size: 1.2rem;
-    }
-    em {
-      color: #666;
+      margin: 0;
     }
   `;
 
@@ -29,13 +30,13 @@ export class MainQueueDisplay extends LitElement {
     const items = this.queue.slice(0, displayCount);
     while (items.length < displayCount) items.push(null);
     return html`
-      <ul aria-label="Upcoming singers queue">
+      <ul class="list" aria-label="Upcoming singers queue">
         ${items.map(
           (q, i) => html`<li>
-            <strong>${i + 1}.</strong>
-            ${q
-              ? html`${q.singer}`
-              : html`<em>Waiting for singer...</em>`}
+            <main-queue-item
+              .position=${i + 1}
+              .singer=${q ? q.singer : ''}
+            ></main-queue-item>
           </li>`,
         )}
       </ul>

--- a/frontend/main-queue-item.js
+++ b/frontend/main-queue-item.js
@@ -1,0 +1,46 @@
+import { LitElement, html, css } from 'lit';
+
+export class MainQueueItem extends LitElement {
+  static properties = {
+    position: { type: Number },
+    singer: { type: String },
+  };
+
+  constructor() {
+    super();
+    this.position = 0;
+    this.singer = '';
+  }
+
+  static styles = css`
+    :host {
+      display: block;
+      padding: 0.25rem 0;
+    }
+    .pos {
+      color: var(--accent-color, #ff4081);
+      margin-right: 0.5rem;
+      font-weight: bold;
+    }
+    .singer {
+      font-size: 1.25rem;
+      font-weight: bold;
+    }
+    em {
+      color: #666;
+    }
+  `;
+
+  render() {
+    return html`
+      <div>
+        <span class="pos">${this.position}.</span>
+        ${this.singer
+          ? html`<span class="singer">${this.singer}</span>`
+          : html`<em>Waiting for singer...</em>`}
+      </div>
+    `;
+  }
+}
+
+customElements.define('main-queue-item', MainQueueItem);

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,2 +1,3 @@
+import './app-theme.js';
 import './hello-lit.js';
 import './karaoke-app.js';

--- a/tasks/tasks-prd-karafun-like-frontend.md
+++ b/tasks/tasks-prd-karafun-like-frontend.md
@@ -41,7 +41,7 @@
         passkey APIs successfully.
   - [x] **4.5** Serve the KJ dashboard at `/admin` when authenticated.
   - [x] **4.6** Print the `/admin/<uuid>` link to the console on server start.
-- [ ] **5.0** Design the main screen showing upcoming singers and content
+- [x] **5.0** Design the main screen showing upcoming singers and content
 - [x] **5.1** Display at least the next five singers in `main-queue-display`.
   - [x] **5.2** Load session content from Firestore and Drupal when available.
   - [x] **5.3** Ensure layouts are responsive across phones, tablets and desktops.


### PR DESCRIPTION
## Summary
- design the main screen and theme
- show queue entries with `main-queue-item`
- apply global dark theme
- check off task 5.0

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b1112ced48325a6802f6015d0f37e