### PR TITLE
Implement singer profile persistence

### DIFF
--- a/__tests__/singerProfiles.test.js
+++ b/__tests__/singerProfiles.test.js
@@ -1,0 +1,34 @@
+import { describe, test, beforeEach, expect, vi } from 'vitest';
+import { TextEncoder, TextDecoder } from 'util';
+import request from 'supertest';
+
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+
+let app;
+
+beforeEach(async () => {
+  vi.resetModules();
+  process.env.YOUTUBE_API_KEY = 'test';
+  const mod = await import('../server.js');
+  app = mod.default || mod;
+});
+
+describe('singer profiles', () => {
+  test('completing a song records history', async () => {
+    const session = await request(app).post('/sessions');
+    const { code } = session.body;
+    const joinRes = await request(app)
+      .post(`/sessions/${code}/join`)
+      .send({ name: 'Alice' });
+    const deviceId = joinRes.body.deviceId;
+    const addRes = await request(app)
+      .post('/songs')
+      .send({ videoId: 'VIDPROF1234', singer: 'Alice' });
+    const songId = addRes.body.id;
+    await request(app).post(`/songs/${songId}/complete`);
+    const profile = await request(app).get(`/singers/${deviceId}`);
+    expect(profile.body.history.length).toBe(1);
+    expect(profile.body.history[0].videoId).toBe('VIDPROF1234');
+  });
+});

--- a/tasks/tasks-prd-karafun-like-frontend.md
+++ b/tasks/tasks-prd-karafun-like-frontend.md
@@ -53,7 +53,7 @@
 - [ ] **7.0** Session & Login Persistence
   - [x] **7.1** Persist active session data (queue, singers, stats) in Firestore so a restart can restore the current room
   - [x] **7.2** Restore the most recent session on server startup
-  - [ ] **7.3** Track singer profiles (rating, song history, notes) across sessions
+  - [x] **7.3** Track singer profiles (rating, song history, notes) across sessions
   - [ ] **7.4** Expose endpoints for alternate admin UIs to manage the queue and session
   - [ ] **7.5** Implement server‑side session cookies so the KJ remains logged in
   - [ ] **7.6** Persist passkey device registrations in Firestore


### PR DESCRIPTION
## Summary
- track singer profiles with rating, notes and song history
- expose `GET` and `PUT /singers/:deviceId` endpoints
- store profile updates when songs are completed
- update tasks to mark profile persistence complete
- add unit test for singer profile history

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e` *(fails: browser not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b4f7ebd488325806a90cd136ca04d