### PR TITLE
Implement server-side session cookies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ FIREBASE_PROJECT_ID=your-project-id
 DRUPAL_CONTENT_URL=https://your-drupal-site.example/jsonapi/session-content
 # Uncomment to use the local Firestore emulator
 # FIRESTORE_EMULATOR_HOST=localhost:8080
+SESSION_SECRET=change-me

--- a/__tests__/sessionCookie.test.js
+++ b/__tests__/sessionCookie.test.js
@@ -1,0 +1,32 @@
+import { describe, test, beforeEach, expect, vi } from 'vitest';
+import { TextEncoder, TextDecoder } from 'util';
+import request from 'supertest';
+
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+
+vi.mock('../kjAuth.js', () => ({
+  generateRegistration: vi.fn(),
+  verifyRegistration: vi.fn(() => Promise.resolve(true)),
+  generateAuth: vi.fn(),
+  verifyAuth: vi.fn(() => Promise.resolve(true)),
+}));
+
+let app;
+
+beforeEach(async () => {
+  vi.resetModules();
+  process.env.YOUTUBE_API_KEY = 'test';
+  const mod = await import('../server.js');
+  app = mod.default || mod;
+});
+
+describe('auth session cookies', () => {
+  test('login sets session cookie', async () => {
+    const res = await request(app).post('/auth/login/verify').send({});
+    expect(res.body.verified).toBe(true);
+    const cookies = res.headers['set-cookie'];
+    expect(cookies).toBeDefined();
+    expect(cookies.some((c) => c.startsWith('connect.sid'))).toBe(true);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "body-parser": "^1.20.2",
         "dotenv": "^16.5.0",
         "express": "^4.19.2",
+        "express-session": "^1.18.1",
         "firebase-admin": "^12.0.0",
         "firebase-functions": "^4.5.0",
         "googleapis": "^150.0.1",
@@ -4680,6 +4681,40 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-session": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.1.tgz",
+      "integrity": "sha512-a5mtTqEaZvBCL9A9aqkrtfz+3SMDhOVUnjafjo+s7A9Txkq+SVX2DLvSp1Zrv4uCXa3lMSK3viWnh9Gg07PBUA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.7",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.0.2",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -7216,6 +7251,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -7755,6 +7799,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -9230,6 +9283,18 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "body-parser": "^1.20.2",
     "dotenv": "^16.5.0",
     "express": "^4.19.2",
+    "express-session": "^1.18.1",
     "firebase-admin": "^12.0.0",
     "firebase-functions": "^4.5.0",
     "googleapis": "^150.0.1",

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 import dotenv from 'dotenv';
 dotenv.config();
 import express from 'express';
+import session from "express-session";
 import bodyParser from 'body-parser';
 import { google } from 'googleapis';
 import { getFirestore } from './firebase.js';
@@ -26,6 +27,8 @@ const adminId = process.env.ADMIN_UUID || uuidv4();
 process.env.ADMIN_UUID = adminId;
 
 const app = express();
+const sessionSecret = process.env.SESSION_SECRET || "kj-secret";
+app.use(session({ secret: sessionSecret, resave: false, saveUninitialized: false }));
 app.use(bodyParser.json());
 
 // Serve static files for the Lit UI first
@@ -42,6 +45,7 @@ app.post('/auth/register/verify', async (req, res) => {
   try {
     console.log('Registration verification request:', JSON.stringify(req.body, null, 2));
     const verified = await verifyRegistration(req.body);
+    if (verified) req.session.loggedIn = true;
     console.log('Registration verification result:', verified);
     res.json({ verified });
   } catch (err) {
@@ -59,6 +63,7 @@ app.post('/auth/login/verify', async (req, res) => {
   try {
     console.log('Login verification request:', JSON.stringify(req.body));
     const verified = await verifyAuth(req.body);
+    if (verified) req.session.loggedIn = true;
     res.json({ verified });
   } catch (err) {
     console.error('Authentication verification error:', err.message);

--- a/tasks/tasks-prd-karafun-like-frontend.md
+++ b/tasks/tasks-prd-karafun-like-frontend.md
@@ -55,7 +55,7 @@
   - [x] **7.2** Restore the most recent session on server startup
   - [x] **7.3** Track singer profiles (rating, song history, notes) across sessions
   - [ ] **7.4** Expose endpoints for alternate admin UIs to manage the queue and session
-  - [ ] **7.5** Implement server‑side session cookies so the KJ remains logged in
+  - [x] **7.5** Implement server‑side session cookies so the KJ remains logged in
   - [ ] **7.6** Persist passkey device registrations in Firestore
   - [ ] **7.7** Provide `/auth/session` and `/auth/logout` endpoints
   - [ ] **7.8** Check login state on app startup and update the UI accordingly


### PR DESCRIPTION
## Summary
- add express-session middleware and set login cookie when KJ verifies
- update env example with SESSION_SECRET
- mark task 7.5 complete in checklist
- test auth session cookies on server

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684b51cf51e083258509b4e5be3cd0ab