### PR TITLE
Implement passkey device persistence

### DIFF
--- a/__tests__/sessionsEndpoints.test.js
+++ b/__tests__/sessionsEndpoints.test.js
@@ -13,7 +13,8 @@ const mockDb = {
   collection: vi.fn(() => ({
     doc: vi.fn(() => ({
       set: vi.fn(),
-      collection: vi.fn(() => ({ get: singersGet }))
+      get: vi.fn(() => Promise.resolve({ exists: false })),
+      collection: vi.fn(() => ({ get: singersGet })),
     })),
     orderBy: vi.fn(() => ({
       limit: vi.fn(() => ({

--- a/server.js
+++ b/server.js
@@ -13,6 +13,7 @@ import {
   verifyRegistration,
   generateAuth,
   verifyAuth,
+  initAuth,
 } from './kjAuth.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -76,6 +77,7 @@ let db;
 
 (async () => {
   db = await getFirestore();
+  await initAuth(db);
   await restoreLatestSession();
 
   const port = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- persist registered passkey devices in Firestore
- load passkey devices on server startup
- adapt session tests for new Firestore calls

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b51ffe44c832597d35257e0556da5