### PR TITLE
Implement session flag persistence

### DIFF
--- a/__tests__/sessionsEndpoints.test.js
+++ b/__tests__/sessionsEndpoints.test.js
@@ -7,7 +7,20 @@ global.TextDecoder = TextDecoder;
 
 let app;
 
-const sessionData = { code: 'PURPLE-RAIN', preparedContent: { msg: 'hi' }, createdAt: Date.now() };
+const now = Date.now();
+const sessionData = {
+  code: 'PURPLE-RAIN',
+  preparedContent: { msg: 'hi' },
+  createdAt: now,
+  paused: true,
+  phase2Start: now - 1000,
+  queue: [
+    { id: 's1', videoId: 'AAA', singer: 'A', addedAt: now - 3000 },
+    { id: 's2', videoId: 'BBB', singer: 'A', addedAt: now - 2000 },
+    { id: 's3', videoId: 'CCC', singer: 'B', addedAt: now - 1000 },
+  ],
+  singerStats: { A: { songsSung: 5 }, B: { songsSung: 1 } },
+};
 const singersGet = vi.fn(() => Promise.resolve({ docs: [] }));
 const mockDb = {
   collection: vi.fn(() => ({
@@ -39,5 +52,11 @@ describe('sessions endpoints', () => {
     const res = await request(app).get('/sessions/current');
     expect(res.statusCode).toBe(200);
     expect(res.body.preparedContent).toEqual(sessionData.preparedContent);
+  });
+
+  test('restores paused and phase2 flags', async () => {
+    const res = await request(app).get('/queue');
+    expect(res.body.paused).toBe(true);
+    expect(res.body.queue.map((s) => s.id)).toEqual(['s3', 's1', 's2']);
   });
 });

--- a/server.js
+++ b/server.js
@@ -101,7 +101,7 @@ async function saveSessionState() {
   await db
     .collection('sessions')
     .doc(currentSession.id)
-    .set({ queue, singerStats }, { merge: true });
+    .set({ queue, singerStats, paused, phase2Start }, { merge: true });
 }
 
 async function loadSingerProfile(deviceId) {
@@ -248,6 +248,8 @@ async function restoreLatestSession() {
   sessions[session.id] = session;
   queue = session.queue || [];
   singerStats = session.singerStats || {};
+  paused = session.paused || false;
+  phase2Start = session.phase2Start || null;
   if (db) {
     const snap = await db
       .collection('sessions')
@@ -511,12 +513,14 @@ app.post('/songs/:id/skip', (req, res) => {
 
 app.post('/sessions/pause', (req, res) => {
   paused = !!req.body.paused;
+  saveSessionState();
   res.json({ paused });
 });
 
 app.post('/phase2', (req, res) => {
   const { startTime } = req.body;
   phase2Start = startTime ? new Date(startTime).getTime() : Date.now();
+  saveSessionState();
   res.json({ phase2Start });
 });
 
@@ -549,12 +553,14 @@ api.post('/sessions', async (req, res) => {
 
 api.post('/pause', (req, res) => {
   paused = !!req.body.paused;
+  saveSessionState();
   res.json({ paused });
 });
 
 api.post('/phase2', (req, res) => {
   const { startTime } = req.body;
   phase2Start = startTime ? new Date(startTime).getTime() : Date.now();
+  saveSessionState();
   res.json({ phase2Start });
 });
 

--- a/tasks/tasks-prd-karafun-like-frontend.md
+++ b/tasks/tasks-prd-karafun-like-frontend.md
@@ -60,4 +60,4 @@
   - [ ] **7.7** Provide `/auth/session` and `/auth/logout` endpoints
   - [ ] **7.8** Check login state on app startup and update the UI accordingly
   - [ ] **7.9** Add Vitest unit tests and Playwright E2E tests for session persistence
-  - [ ] **7.10** Persist and restore session flags like `paused` and `phase2Start`
+  - [x] **7.10** Persist and restore session flags like `paused` and `phase2Start`


### PR DESCRIPTION
## Summary
- persist `paused` and `phase2Start` in Firestore
- restore these values on startup
- update pause/phase2 endpoints to save state
- mark task 7.10 complete
- test restoration of session flags

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b52853aa083258fd2d7a5b8c9b6f2