### PR TITLE
Implement login session check

### DIFF
--- a/__tests__/authEndpoints.test.js
+++ b/__tests__/authEndpoints.test.js
@@ -15,6 +15,7 @@ beforeEach(async () => {
     verifyRegistration: vi.fn(() => true),
     generateAuth: vi.fn(),
     verifyAuth: vi.fn(() => true),
+    initAuth: vi.fn(() => Promise.resolve()),
   }));
   const mod = await import('../server.js');
   app = mod.default || mod;

--- a/__tests__/sessionCookie.test.js
+++ b/__tests__/sessionCookie.test.js
@@ -10,6 +10,7 @@ vi.mock('../kjAuth.js', () => ({
   verifyRegistration: vi.fn(() => Promise.resolve(true)),
   generateAuth: vi.fn(),
   verifyAuth: vi.fn(() => Promise.resolve(true)),
+  initAuth: vi.fn(() => Promise.resolve()),
 }));
 
 let app;

--- a/frontend/karaoke-app.js
+++ b/frontend/karaoke-app.js
@@ -19,6 +19,21 @@ class KJView extends LitElement {
     this.loggedIn = localStorage.getItem('kjLoggedIn') === 'true';
   }
 
+  connectedCallback() {
+    super.connectedCallback();
+    fetch('/auth/session')
+      .then((r) => r.json())
+      .then((data) => {
+        this.loggedIn = data.loggedIn;
+        if (data.loggedIn) {
+          localStorage.setItem('kjLoggedIn', 'true');
+        } else {
+          localStorage.removeItem('kjLoggedIn');
+        }
+      })
+      .catch((err) => console.error('login state check failed', err));
+  }
+
   _onLogin() {
     this.loggedIn = true;
     localStorage.setItem('kjLoggedIn', 'true');

--- a/frontend/karaoke-app.test.js
+++ b/frontend/karaoke-app.test.js
@@ -1,0 +1,30 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, beforeEach, test, expect, vi } from 'vitest';
+import './karaoke-app.js';
+
+function flush() {
+  return new Promise((r) => setTimeout(r, 0));
+}
+
+describe('kj-view startup login check', () => {
+  let element;
+  beforeEach(async () => {
+    document.body.innerHTML = '';
+    localStorage.clear();
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ json: () => Promise.resolve({ loggedIn: true }) })
+    );
+    element = document.createElement('kj-view');
+    document.body.appendChild(element);
+    await flush();
+  });
+
+  test('fetches /auth/session and updates login state', async () => {
+    expect(fetch).toHaveBeenCalledWith('/auth/session');
+    await flush();
+    expect(element.loggedIn).toBe(true);
+    expect(localStorage.getItem('kjLoggedIn')).toBe('true');
+  });
+});


### PR DESCRIPTION
## Summary
- query `/auth/session` when `kj-view` loads and sync `kjLoggedIn`
- add unit test for session check
- fix tests by mocking `initAuth`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b594df1448325b063b5e45a4cc67f