### PR TITLE
Implement passkey persistence test

### DIFF
--- a/__tests__/kjAuthPersistence.test.js
+++ b/__tests__/kjAuthPersistence.test.js
@@ -1,0 +1,44 @@
+import { describe, test, expect, vi } from 'vitest';
+vi.mock('@simplewebauthn/server', () => ({
+  generateRegistrationOptions: vi.fn(() => ({ challenge: 'reg' })),
+  verifyRegistrationResponse: vi.fn(() => Promise.resolve({
+    verified: true,
+    registrationInfo: {
+      credential: {
+        id: 'aWQ',
+        publicKey: 'pk',
+        counter: 0,
+      },
+    },
+  })),
+  generateAuthenticationOptions: vi.fn(({ allowCredentials }) => ({ challenge: 'auth', allowCredentials })),
+  verifyAuthenticationResponse: vi.fn(() => Promise.resolve({ verified: true, authenticationInfo: { newCounter: 1 } })),
+}));
+
+function createDb() {
+  const store = {};
+  return {
+    collection: () => ({
+      doc: (id) => ({
+        async get() { return { exists: !!store[id], data: () => store[id] }; },
+        async set(data) { store[id] = data; },
+      }),
+    }),
+  };
+}
+
+describe('passkey persistence', () => {
+  test('devices saved to firestore are loaded on init', async () => {
+    const db = createDb();
+    let mod = await import('../kjAuth.js');
+    await mod.initAuth(db);
+    await mod.verifyRegistration({ rawId: 'cred' });
+
+    // simulate server restart
+    vi.resetModules();
+    mod = await import('../kjAuth.js');
+    await mod.initAuth(db);
+    const opts = await mod.generateAuth();
+    expect(opts.allowCredentials.length).toBeGreaterThan(0);
+  });
+});

--- a/tasks/tasks-prd-karafun-like-frontend.md
+++ b/tasks/tasks-prd-karafun-like-frontend.md
@@ -56,7 +56,7 @@
   - [x] **7.3** Track singer profiles (rating, song history, notes) across sessions
   - [x] **7.4** Expose endpoints for alternate admin UIs to manage the queue and session
   - [x] **7.5** Implement server‑side session cookies so the KJ remains logged in
-  - [ ] **7.6** Persist passkey device registrations in Firestore
+  - [x] **7.6** Persist passkey device registrations in Firestore
   - [x] **7.7** Provide `/auth/session` and `/auth/logout` endpoints
   - [ ] **7.8** Check login state on app startup and update the UI accordingly
   - [ ] **7.9** Add Vitest unit tests and Playwright E2E tests for session persistence


### PR DESCRIPTION
## Summary
- mark task 7.6 complete
- add unit test for persisting passkey registrations

## Testing
- `npm run lint`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684b5a88990c83258e4fb185efabdf13