### PR TITLE
Add login persistence e2e test

### DIFF
--- a/e2e/session-persistence.spec.js
+++ b/e2e/session-persistence.spec.js
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+import { startServer } from './utils.js';
+
+let server;
+let adminUrl;
+
+// Start a fresh server before each test
+test.beforeEach(async () => {
+  const started = startServer();
+  server = started.server;
+  adminUrl = await started.ready;
+});
+
+test.afterEach(() => {
+  server?.kill();
+});
+
+test('login persists across reload', async ({ page, context }) => {
+  const cdp = await context.newCDPSession(page);
+  await cdp.send('WebAuthn.enable');
+  const { authenticatorId } = await cdp.send('WebAuthn.addVirtualAuthenticator', {
+    options: {
+      protocol: 'ctap2',
+      transport: 'internal',
+      hasResidentKey: true,
+      hasUserVerification: true,
+      isUserVerified: true,
+    },
+  });
+
+  await page.goto(adminUrl);
+  const gotIt = page.getByRole('button', { name: 'Got It!' });
+  if (await gotIt.isVisible().catch(() => false)) {
+    await gotIt.click();
+  }
+
+  await page.getByRole('button', { name: 'Register Passkey' }).click();
+  await page.waitForLoadState('networkidle');
+  await expect(
+    page.getByRole('button', { name: 'Start a new karaoke session' })
+  ).toBeVisible({ timeout: 10000 });
+
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+  await expect(
+    page.getByRole('button', { name: 'Start a new karaoke session' })
+  ).toBeVisible({ timeout: 10000 });
+  await expect(
+    page.getByRole('button', { name: 'Register Passkey' }).first()
+  ).toBeHidden();
+
+  await cdp.send('WebAuthn.removeVirtualAuthenticator', { authenticatorId });
+});
+

--- a/tasks/tasks-prd-karafun-like-frontend.md
+++ b/tasks/tasks-prd-karafun-like-frontend.md
@@ -58,6 +58,6 @@
   - [x] **7.5** Implement server‑side session cookies so the KJ remains logged in
   - [x] **7.6** Persist passkey device registrations in Firestore
   - [x] **7.7** Provide `/auth/session` and `/auth/logout` endpoints
-  - [ ] **7.8** Check login state on app startup and update the UI accordingly
+  - [x] **7.8** Check login state on app startup and update the UI accordingly
   - [ ] **7.9** Add Vitest unit tests and Playwright E2E tests for session persistence
   - [x] **7.10** Persist and restore session flags like `paused` and `phase2Start`


### PR DESCRIPTION
## Summary
- mark task 7.8 complete
- add a Playwright test verifying KJ login persists across reloads

## Testing
- `npm test`
- `npm run lint`
- `npm run test:e2e` *(fails: missing Playwright browser)*

------
https://chatgpt.com/codex/tasks/task_e_684b656b2cd8832580f0043e42be5a5b