### PR TITLE
Add session persistence tests

### DIFF
--- a/__tests__/sessionPersistence.test.js
+++ b/__tests__/sessionPersistence.test.js
@@ -1,0 +1,80 @@
+import { describe, test, beforeEach, expect, vi } from 'vitest';
+import { TextEncoder, TextDecoder } from 'util';
+import request from 'supertest';
+
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+
+function createDb() {
+  const store = {};
+  return {
+    collection: (name) => ({
+      doc: (id) => ({
+        async get() {
+          const col = store[name] || {};
+          return { exists: id in col, data: () => col[id] };
+        },
+        async set(data) {
+          store[name] = store[name] || {};
+          store[name][id] = { ...(store[name][id] || {}), ...data };
+        },
+        collection: (sub) => ({
+          doc: (sid) => ({
+            async set(data) {
+              const key = `${name}.${id}.${sub}`;
+              store[key] = store[key] || {};
+              store[key][sid] = data;
+            },
+          }),
+          async get() {
+            const key = `${name}.${id}.${sub}`;
+            const docs = Object.entries(store[key] || {}).map(([sid, d]) => ({ id: sid, data: () => d }));
+            return { docs };
+          },
+        }),
+      }),
+      orderBy: () => ({
+        limit: () => ({
+          async get() {
+            const col = store[name] || {};
+            const docs = Object.entries(col).map(([sid, d]) => ({ id: sid, data: () => d }));
+            docs.sort((a, b) => (b.data().createdAt || 0) - (a.data().createdAt || 0));
+            if (!docs.length) return { empty: true, docs: [] };
+            return { empty: false, docs: [docs[0]] };
+          },
+        }),
+      }),
+    }),
+  };
+}
+
+let db;
+let app;
+
+beforeEach(async () => {
+  vi.resetModules();
+  db = createDb();
+  vi.mock('../firebase.js', () => ({ getFirestore: () => db }));
+  process.env.YOUTUBE_API_KEY = 'test';
+  const mod = await import('../server.js');
+  app = mod.default || mod;
+});
+
+describe('session persistence', () => {
+  test('queue saved to firestore is restored on restart', async () => {
+    const session = await request(app).post('/sessions');
+    const { code } = session.body;
+    await request(app).post(`/sessions/${code}/join`).send({ name: 'Alice' });
+    await request(app).post('/songs').send({ videoId: 'ABCDEFGHIJK', singer: 'Alice' });
+    const first = await request(app).get('/queue');
+    expect(first.body.queue.length).toBe(1);
+
+    vi.resetModules();
+    vi.mock('../firebase.js', () => ({ getFirestore: () => db }));
+    const mod2 = await import('../server.js');
+    const app2 = mod2.default || mod2;
+    const second = await request(app2).get('/queue');
+    expect(second.body.queue.length).toBe(1);
+    expect(second.body.queue[0].videoId).toBe('ABCDEFGHIJK');
+  });
+});

--- a/e2e/session-persistence.spec.js
+++ b/e2e/session-persistence.spec.js
@@ -52,3 +52,38 @@ test('login persists across reload', async ({ page, context }) => {
   await cdp.send('WebAuthn.removeVirtualAuthenticator', { authenticatorId });
 });
 
+
+test('queue persists across page reload', async ({ page, context }) => {
+  const cdp = await context.newCDPSession(page);
+  await cdp.send('WebAuthn.enable');
+  const { authenticatorId } = await cdp.send('WebAuthn.addVirtualAuthenticator', {
+    options: {
+      protocol: 'ctap2',
+      transport: 'internal',
+      hasResidentKey: true,
+      hasUserVerification: true,
+      isUserVerified: true,
+    },
+  });
+
+  await page.goto(adminUrl);
+  const gotIt = page.getByRole('button', { name: 'Got It!' });
+  if (await gotIt.isVisible().catch(() => false)) {
+    await gotIt.click();
+  }
+
+  await page.getByRole('button', { name: 'Register Passkey' }).click();
+  await page.waitForLoadState('networkidle');
+  await page.getByRole('button', { name: 'Start a new karaoke session' }).click();
+  await page.waitForSelector('kj-control-panel');
+  await page.getByPlaceholder('Singer').fill('Bob');
+  await page.getByPlaceholder('Video ID').fill('VID12345');
+  await page.getByRole('button', { name: 'Add' }).click();
+  await expect(page.locator('kj-control-panel li')).toContainText('Bob');
+
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+  await expect(page.locator('kj-control-panel li')).toContainText('Bob');
+
+  await cdp.send('WebAuthn.removeVirtualAuthenticator', { authenticatorId });
+});

--- a/tasks/tasks-prd-karafun-like-frontend.md
+++ b/tasks/tasks-prd-karafun-like-frontend.md
@@ -59,5 +59,5 @@
   - [x] **7.6** Persist passkey device registrations in Firestore
   - [x] **7.7** Provide `/auth/session` and `/auth/logout` endpoints
   - [x] **7.8** Check login state on app startup and update the UI accordingly
-  - [ ] **7.9** Add Vitest unit tests and Playwright E2E tests for session persistence
+  - [x] **7.9** Add Vitest unit tests and Playwright E2E tests for session persistence
   - [x] **7.10** Persist and restore session flags like `paused` and `phase2Start`


### PR DESCRIPTION
## Summary
- mark session persistence tests complete in tasks
- add vitest unit test covering queue persistence
- extend Playwright test for queue persistence

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e` *(fails: could not download Playwright browser)*

------
https://chatgpt.com/codex/tasks/task_e_684b79760a0c83259783bf1f7ca8a7e7