### PR TITLE
Improve Firestore error handling in auth

### DIFF
--- a/kjAuth.js
+++ b/kjAuth.js
@@ -59,20 +59,28 @@ function deserializeDevice(data) {
 
 async function loadDevices() {
   if (!db) return;
-  const doc = await db.collection('passkeyDevices').doc('kj').get();
-  if (!doc.exists) return;
-  const data = doc.data();
-  if (data && Array.isArray(data.devices)) {
-    kjUser.devices = data.devices.map(deserializeDevice);
+  try {
+    const doc = await db.collection('passkeyDevices').doc('kj').get();
+    if (!doc.exists) return;
+    const data = doc.data();
+    if (data && Array.isArray(data.devices)) {
+      kjUser.devices = data.devices.map(deserializeDevice);
+    }
+  } catch (err) {
+    console.error('Failed to load passkey devices from Firestore:', err.message);
   }
 }
 
 async function saveDevices() {
   if (!db) return;
-  await db
-    .collection('passkeyDevices')
-    .doc('kj')
-    .set({ devices: kjUser.devices.map(serializeDevice) });
+  try {
+    await db
+      .collection('passkeyDevices')
+      .doc('kj')
+      .set({ devices: kjUser.devices.map(serializeDevice) });
+  } catch (err) {
+    console.error('Failed to save passkey devices to Firestore:', err.message);
+  }
 }
 
 export async function initAuth(firestore = getFirestore()) {


### PR DESCRIPTION
## Summary
- handle errors while reading/writing passkey device data

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e` *(fails: browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b7ba5c4488325b3003adb13392303