### PR TITLE
Complete Task 2 Login UI

### DIFF
--- a/src/frontend/karaoke-app.js
+++ b/src/frontend/karaoke-app.js
@@ -8,6 +8,7 @@ import './guest-songbook.js';
 import './main-screen-view.js';
 import './settings-profile.js';
 import './onboarding-flow.js';
+import './login-form.js';
 
 class KJView extends LitElement {
   static properties = {
@@ -101,6 +102,7 @@ export class KaraokeApp extends LitElement {
     route: { state: true },
     onboardingComplete: { state: true },
     roomCode: { state: true },
+    stageName: { state: true },
   };
 
   constructor() {
@@ -108,6 +110,7 @@ export class KaraokeApp extends LitElement {
     this.route = this._getRoute();
     this.onboardingComplete = localStorage.getItem('onboardingComplete') === 'true';
     this.roomCode = null;
+    this.stageName = localStorage.getItem('stageName');
     this._onPopState = () => {
       this.route = this._getRoute();
     };
@@ -115,6 +118,10 @@ export class KaraokeApp extends LitElement {
 
   _onSessionCreated(e) {
     this.roomCode = e.detail.code;
+  }
+
+  _onLoggedIn(e) {
+    this.stageName = e.detail.name;
   }
 
   connectedCallback() {
@@ -171,6 +178,10 @@ export class KaraokeApp extends LitElement {
 
     if (!this.onboardingComplete) {
       return html`<onboarding-flow @onboarding-complete=${this._handleOnboardingComplete}></onboarding-flow>`;
+    }
+
+    if (this.route !== 'kj' && !this.stageName) {
+      return html`<login-form @login=${this._onLoggedIn}></login-form>`;
     }
 
     return html`

--- a/src/frontend/login-form.js
+++ b/src/frontend/login-form.js
@@ -1,0 +1,166 @@
+import { LitElement, html, css } from 'lit';
+
+function base64urlToUint8Array(base64url) {
+  const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
+  const paddingLength = (4 - base64.length % 4) % 4;
+  const padded = base64 + '='.repeat(paddingLength);
+  return Uint8Array.from(atob(padded), (c) => c.charCodeAt(0));
+}
+
+function bufToB64(buf) {
+  const bin = String.fromCharCode(...new Uint8Array(buf));
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function decodeOpts(opts) {
+  if (!opts) return opts;
+  const out = { ...opts };
+  if (out.challenge) out.challenge = base64urlToUint8Array(out.challenge);
+  if (out.user && out.user.id) out.user.id = base64urlToUint8Array(out.user.id);
+  if (Array.isArray(out.allowCredentials)) {
+    out.allowCredentials = out.allowCredentials.map((c) => ({
+      ...c,
+      id: base64urlToUint8Array(c.id),
+    }));
+  }
+  if (Array.isArray(out.excludeCredentials)) {
+    out.excludeCredentials = out.excludeCredentials.map((c) => ({
+      ...c,
+      id: base64urlToUint8Array(c.id),
+    }));
+  }
+  return out;
+}
+
+function credToJSON(cred) {
+  if (cred instanceof ArrayBuffer) {
+    return bufToB64(cred);
+  } else if (Array.isArray(cred)) {
+    return cred.map(credToJSON);
+  } else if (cred && cred.constructor && cred.constructor.name === 'PublicKeyCredential') {
+    return {
+      id: cred.id,
+      rawId: credToJSON(cred.rawId),
+      response: {
+        clientDataJSON: credToJSON(cred.response.clientDataJSON),
+        attestationObject: cred.response.attestationObject ? credToJSON(cred.response.attestationObject) : undefined,
+        authenticatorData: cred.response.authenticatorData ? credToJSON(cred.response.authenticatorData) : undefined,
+        signature: cred.response.signature ? credToJSON(cred.response.signature) : undefined,
+        userHandle: cred.response.userHandle ? credToJSON(cred.response.userHandle) : undefined,
+      },
+      type: cred.type,
+    };
+  } else if (cred && cred.constructor && cred.constructor.name === 'AuthenticatorAttestationResponse') {
+    return {
+      clientDataJSON: credToJSON(cred.clientDataJSON),
+      attestationObject: credToJSON(cred.attestationObject),
+    };
+  } else if (cred && cred.constructor && cred.constructor.name === 'AuthenticatorAssertionResponse') {
+    return {
+      clientDataJSON: credToJSON(cred.clientDataJSON),
+      authenticatorData: credToJSON(cred.authenticatorData),
+      signature: credToJSON(cred.signature),
+      userHandle: cred.userHandle ? credToJSON(cred.userHandle) : undefined,
+    };
+  } else if (cred && typeof cred === 'object') {
+    const obj = {};
+    for (const [k, v] of Object.entries(cred)) {
+      obj[k] = credToJSON(v);
+    }
+    return obj;
+  }
+  return cred;
+}
+
+export class LoginForm extends LitElement {
+  static properties = {
+    name: { state: true },
+    error: { state: true },
+  };
+
+  constructor() {
+    super();
+    this.name = localStorage.getItem('stageName') || '';
+    this.error = '';
+  }
+
+  _onInput(e) {
+    this.name = e.target.value;
+  }
+
+  async _confirm() {
+    this.error = '';
+    if (!this.name.trim()) {
+      this.error = 'Please enter a Stage Name';
+      return;
+    }
+    localStorage.setItem('stageName', this.name.trim());
+    try {
+      const optsRaw = await fetch('/auth/register/options').then((r) => r.json());
+      const opts = decodeOpts(optsRaw);
+      const cred = await navigator.credentials.create({ publicKey: opts });
+      const res = await fetch('/auth/register/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(credToJSON(cred)),
+      }).then((r) => r.json());
+      if (!res.verified) {
+        throw new Error('Registration failed');
+      }
+      this.dispatchEvent(
+        new CustomEvent('login', { detail: { name: this.name.trim() }, bubbles: true, composed: true }),
+      );
+    } catch (err) {
+      this.error = err.message;
+    }
+  }
+
+  render() {
+    return html`
+      <div class="container">
+        <h2>Welcome to Karaoke MN</h2>
+        <form @submit=${(e) => { e.preventDefault(); this._confirm(); }}>
+          <label for="stage">Stage Name</label>
+          <input id="stage" .value=${this.name} @input=${this._onInput} placeholder="Stage Name" autofocus />
+          <button type="submit">Confirm</button>
+        </form>
+        ${this.error ? html`<p class="error" aria-live="polite">${this.error}</p>` : ''}
+      </div>
+    `;
+  }
+
+  static styles = css`
+    :host {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      background: var(--bg-color);
+      color: var(--text-color);
+    }
+    .container {
+      background: var(--surface-color);
+      padding: 2rem;
+      border-radius: 8px;
+      box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+      text-align: center;
+    }
+    input {
+      padding: 0.5rem;
+      margin-top: 0.5rem;
+      border-radius: 4px;
+      border: 1px solid #555;
+      width: 100%;
+      box-sizing: border-box;
+    }
+    button {
+      margin-top: 1rem;
+    }
+    .error {
+      color: #ff5252;
+      margin-top: 0.5rem;
+    }
+  `;
+}
+
+customElements.define('login-form', LoginForm);

--- a/tasks/tasks-prd-ui-design.md
+++ b/tasks/tasks-prd-ui-design.md
@@ -13,7 +13,7 @@
   - [x] 2.2 Integrate WebAuthn passkey flows via `kjAuth.js`.
   - [x] 2.3 Persist StageName and credentials in `localStorage`.
   - [x] 2.4 Redirect or display errors based on authentication result.
-  - [ ] 2.5 Ensure Login/Splash UI matches design mock (Login-Splash-Screen.jpg)
+  - [x] 2.5 Ensure Login/Splash UI matches design mock (Login-Splash-Screen.jpg)
 
 - [ ] 3.0 Main Search Screen Layout and Components
 


### PR DESCRIPTION
## Summary
- add `<login-form>` component to capture Stage Name and register a passkey
- hook the new login form into `karaoke-app` so guests authenticate before using the app
- mark login splash task as complete in project checklist

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint-plugin-import')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cc305f8a4832586564bb93efe0643